### PR TITLE
docs: use standard MIT license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -12,9 +12,6 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-Third-party materials, archived ebooks, external articles, linked resources,
-and quoted references remain under their original licenses and copyrights.
-
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Existing content will be gradually incorporated into new learning paths. See the
 - [Roadmap](ROADMAP.md)
 - [Maintainers](MAINTAINERS.md)
 
+Original project content is licensed under the MIT License. Third-party materials, archived ebooks, external articles, linked resources, and quoted references remain under their original licenses and copyrights.
+
 ## Contributing
 
 We welcome contributions of real-world problems, team practices, incident recovery experiences, AI programming workflows, and reusable templates.

--- a/README_zh.md
+++ b/README_zh.md
@@ -150,6 +150,8 @@ v2.0 版本的定位是：
 - [Roadmap](ROADMAP.md)
 - [Maintainers](MAINTAINERS.md)
 
+本仓库原创内容采用 MIT License。第三方资料、历史电子书、外部文章、链接资源和引用内容仍遵循其原始许可证和版权声明。
+
 ## Contributing
 
 欢迎贡献真实问题、团队实践、事故恢复经验、AI 编程工作流和可复用模板。


### PR DESCRIPTION
## Summary

- Restore LICENSE to standard MIT text for GitHub license detection
- Move third-party material notes into README and README_zh

## Validation

- python3 scripts/check-docs.py
- git diff --check