### PR TITLE
docs: add AI agent governance guide

### DIFF
--- a/04-github-engineering/04-github-engineering_en/README_en.md
+++ b/04-github-engineering/04-github-engineering_en/README_en.md
@@ -14,6 +14,7 @@ This directory is intended for tech leads and team maintainers. Its goal is to c
 | Want to unify rules across multiple repositories | [Rulesets](rulesets_en.md) |
 | Key directories require owner review | [CODEOWNERS](codeowners_en.md) |
 | Too many PRs, main branch breaks frequently on merge | [Merge Queue](merge-queue_en.md) |
+| AI agents are starting to push code and need governance rules | [AI Agent Governance](ai-agent-governance_en.md) |
 
 ## CI and Release
 

--- a/04-github-engineering/04-github-engineering_en/ai-agent-governance_en.md
+++ b/04-github-engineering/04-github-engineering_en/ai-agent-governance_en.md
@@ -1,0 +1,132 @@
+# AI Agent Governance
+
+English | [中文](../ai-agent-governance.md)
+
+When AI agents start creating branches, committing code, and opening PRs, the repository gains a new class of participants. Governance now covers agents as well as humans, and existing branch protection, review rules, and CI policies deserve a fresh look.
+
+This guide answers five questions:
+
+1. What identity do agents use to commit code?
+2. How should agent permissions be scoped down?
+3. Who approves PRs opened by agents?
+4. How do agents trigger CI, and how are secrets isolated?
+5. How do you trace a problem back to a specific agent session?
+
+## Three Identity Models for Agents
+
+### 1. Tools running locally under a human account
+
+Claude Code, Codex CLI, and Aider run on a developer's machine, and commits appear under the developer's own identity.
+
+Governance focus:
+
+- Mark tool involvement in commit messages with a `Co-authored-by` trailer.
+- Developers take full responsibility for all code pushed under their accounts.
+- Write team rules into AGENTS.md so every member's agent follows the same boundaries.
+
+```text
+fix(order): handle empty timeout config
+
+Co-authored-by: Claude <noreply@anthropic.com>
+```
+
+### 2. Platform-hosted agents
+
+Agents such as GitHub Copilot cloud agent and Codex cloud run in platform sandboxes and commit under separate bot identities.
+
+Taking Copilot cloud agent as an example, GitHub ships these built-in restrictions (see the official documentation at the end):
+
+- Only users with write access can trigger the agent, and comments from users without write access are never passed to it.
+- The agent can only push to its own `copilot/` branches and is still subject to branch protections and required checks.
+- PRs opened by the agent are drafts. The agent cannot mark them ready for review, approve them, or merge them.
+- The person who started the task cannot approve the resulting PR, so the Required approvals control is preserved.
+- By default, Actions workflows do not run until a user with write access clicks Approve and run workflows.
+
+Governance focus: confirm these defaults have not been loosened before deciding which repositories to open up to hosted agents.
+
+### 3. Agents inside self-built automation
+
+When teams run agents inside GitHub Actions or internal platforms, the identity is usually a GitHub App or a machine user.
+
+Governance focus:
+
+- Prefer a GitHub App over a personal access token. App permissions can be scoped per repository and per capability.
+- One identity per purpose, which keeps auditing and revocation simple.
+- Use fine-grained tokens limited to the repositories the task actually needs.
+
+## Permission Design
+
+Core principle: grant agents the smallest permission set that the task requires.
+
+- Restrict write access to a dedicated branch prefix. Use branch name targeting in Rulesets so agents can only push to `ai/**` or `copilot/**`.
+- Never grant agents any bypass. Agent identities should not appear in a Ruleset bypass list.
+- Do not grant admin rights, and do not let agents change repository settings, webhooks, or Actions configuration.
+- Use CODEOWNERS as the backstop for high-risk directories, and keep owners human.
+
+## PR Approval Rules
+
+- PRs opened by agents must be approved by a human. Enable Require approvals.
+- Keep the task initiator and the approver separate. Hosted agent platforms usually build this in; self-built agents need a process rule to cover it.
+- Enable Require review from Code Owners for high-risk paths.
+- Treat AI review output as advisory input only. The approval action must come from a human.
+
+## CI Triggers and Secrets Isolation
+
+Once agent-authored code runs in CI, that code holds execution rights in the CI environment. Three control points:
+
+- Keep the default behavior of human approval before workflows run, especially on public repositories.
+- Move deployment secrets into environments with required reviewers, so agent branches cannot reach them.
+- Be careful with `pull_request_target`, which runs code from external branches in a context that carries secrets.
+
+Hosted agent environments restrict outbound network access through a firewall by default. Confirm the list of required domains before loosening it.
+
+## Traceability
+
+When something goes wrong, you need to answer: whose agent produced this code, in which session, started by whom.
+
+- Commit authorship must distinguish humans from agents. Hosted agents commit under a bot identity with the initiator as co-author, and the commits are signed.
+- Local tools should consistently add a `Co-authored-by` trailer.
+- Keep a task or session link in the commit message.
+- Retain platform session logs and audit logs for review.
+
+## Minimal Setup
+
+A small team needs only four things to start:
+
+1. Agree on an agent branch prefix and write it into AGENTS.md and the branch naming convention.
+2. Enable Require a pull request before merging and Require approvals on the main branch.
+3. Agree on commit trailers that mark AI involvement.
+4. Move deployment secrets into environments.
+
+Growing teams can then add:
+
+- Rulesets to unify agent branch rules across repositories.
+- CODEOWNERS coverage for high-risk directories.
+- A GitHub App identity for self-built agents.
+- Periodic audits of agent identity permissions and activity.
+
+## Common Mistakes
+
+### 1. Granting agents the same permissions as humans
+
+Agents do not need admin, do not need bypass, and do not need access to every repository. Oversized permissions make audits unable to tell humans and agents apart.
+
+### 2. Sharing one token across all agents
+
+A shared token means no accountability and no selective revocation. One identity per purpose.
+
+### 3. Treating AI review as human approval
+
+AI review can run a first pass, but Required approvals must be satisfied by a human.
+
+### 4. No naming convention for agent branches
+
+Without a unified prefix, auditing, cleanup, and Ruleset targeting all become impossible.
+
+## Extended Reading
+
+- [GitHub Docs: Risks and mitigations for Copilot cloud agent](https://docs.github.com/en/copilot/concepts/agents/cloud-agent/risks-and-mitigations)
+- [Rulesets](rulesets_en.md)
+- [Branch Protection](branch-protection_en.md)
+- [CODEOWNERS](codeowners_en.md)
+- [AI Reviewer and Human Reviewer](../../05-ai-native-development/05-ai-native-development_en/ai-reviewer-and-human-reviewer_en.md)

--- a/04-github-engineering/README.md
+++ b/04-github-engineering/README.md
@@ -14,6 +14,7 @@
 | 多仓库想统一规则 | [Rulesets](rulesets.md) |
 | 关键目录需要 owner Review | [CODEOWNERS](codeowners.md) |
 | PR 多，主分支经常被合坏 | [Merge Queue](merge-queue.md) |
+| AI agent 开始提交代码，要建立治理规则 | [AI Agent 治理](ai-agent-governance.md) |
 
 ## CI 和发布
 

--- a/04-github-engineering/ai-agent-governance.md
+++ b/04-github-engineering/ai-agent-governance.md
@@ -1,0 +1,130 @@
+# AI Agent 治理
+
+当 AI agent 开始创建分支、提交代码、发起 PR，仓库里就多了一类新的参与者。治理对象从人扩展到 agent，原有的分支保护、Review 规则、CI 策略需要重新检查一遍。
+
+这篇回答五个问题：
+
+1. agent 用什么身份提交代码
+2. agent 的权限怎么收紧
+3. agent 发起的 PR 谁来批准
+4. agent 怎么触发 CI，secrets 怎么隔离
+5. 出了问题怎么追溯到具体的 agent 会话
+
+## Agent 的三种身份形态
+
+### 1. 人类账号在本地运行工具
+
+Claude Code、Codex CLI、Aider 在开发者本机运行，提交以开发者本人身份出现。
+
+治理重点：
+
+- 提交信息里标注工具参与，推荐 `Co-authored-by` trailer
+- 开发者对自己账号推出去的所有代码负全责
+- 团队规则写进 AGENTS.md，让每个人的 agent 都遵守同一套边界
+
+```text
+fix(order): handle empty timeout config
+
+Co-authored-by: Claude <noreply@anthropic.com>
+```
+
+### 2. 平台托管 agent
+
+GitHub Copilot cloud agent、Codex cloud 这类 agent 运行在平台沙箱里，以独立的 bot 身份提交。
+
+以 Copilot cloud agent 为例，GitHub 内置了这些限制（来源见文末官方文档）：
+
+- 只有对仓库有 write 权限的人能触发 agent，无权限用户的评论不会传给 agent
+- agent 只能 push 到自己的 `copilot/` 分支，同样受分支保护和必需检查约束
+- agent 发起的 PR 是 draft，agent 自己不能标记 ready、不能 approve、不能 merge
+- 发起任务的人不能批准这个 PR，Required approvals 的控制不会被绕过
+- 默认情况下，有 write 权限的人点击 Approve and run workflows 之后，Actions 才会运行
+
+治理重点：先确认这些默认限制没有被放宽，再决定哪些仓库开放给托管 agent。
+
+### 3. 自建自动化里的 agent
+
+团队在 GitHub Actions 或内部平台里自己跑 agent，身份通常是 GitHub App 或 machine user。
+
+治理重点：
+
+- 优先用 GitHub App，权限可以精确到仓库和能力，避免个人 PAT
+- 一个用途一个身份，方便审计和回收
+- token 用 fine-grained 类型，只授需要的仓库
+
+## 权限设计
+
+核心原则：agent 拿到的权限按它要完成的任务给，按最小集合给。
+
+- 写权限只开到专属分支前缀。用 Rulesets 的分支命名限制，约定 agent 只能推 `ai/**` 或 `copilot/**`
+- 不给 agent 任何 bypass。Rulesets 的 bypass 名单里不应该出现 agent 身份
+- 不给 agent 管理员权限，不让 agent 修改仓库设置、webhook、Actions 配置
+- 高风险目录用 CODEOWNERS 兜底，owner 必须是人
+
+## PR 审批规则
+
+- agent 发起的 PR 必须有人类 approve，开启 Require approvals
+- 发起任务的人和批准的人分开。托管 agent 平台一般内置了这条，自建 agent 要靠流程约定补上
+- 高风险路径开启 Require review from Code Owners
+- AI review 工具的结论只作为参考输入，批准动作必须由人完成
+
+## CI 触发与 secrets 隔离
+
+agent 提交的代码进入 CI 运行时，等于这段代码拿到了 CI 环境的执行权。三个控制点：
+
+- 保持先人工批准、再跑 workflow 的默认行为，公开仓库尤其要保持
+- 部署类 secrets 放进 environment，配置 required reviewers，agent 的分支拿不到
+- 慎用 `pull_request_target`，它会让外部分支的代码在带 secrets 的上下文里运行
+
+托管 agent 的运行环境默认有防火墙限制出网，放宽前先确认要访问的域名清单。
+
+## 可追溯性
+
+出问题时要能回答：这段代码来自谁的 agent、哪次会话、谁发起的。
+
+- 提交署名要能区分人和 agent。托管 agent 的提交由 bot 署名、发起人作为 co-author，提交带签名
+- 本地工具的提交统一加 `Co-authored-by` trailer
+- commit message 里保留任务或会话链接
+- 平台的 session log 和 audit log 保留备查
+
+## 最小落地配置
+
+小团队第一步只需要四件事：
+
+1. 约定 agent 分支前缀，写进 AGENTS.md 和分支命名规范
+2. 主分支开启 Require a pull request before merging 和 Require approvals
+3. 约定提交 trailer 标注 AI 参与
+4. 部署 secrets 移入 environment
+
+成长期团队再补：
+
+- 用 Rulesets 统一多仓库的 agent 分支规则
+- CODEOWNERS 覆盖高风险目录
+- 自建 agent 换成 GitHub App 身份
+- 定期审计 agent 身份的权限和活跃度
+
+## 常见误区
+
+### 1. 给 agent 和人一样的权限
+
+agent 不需要 admin，不需要 bypass，不需要访问所有仓库。权限给大了，审计时分不清是人还是 agent 在操作。
+
+### 2. 所有 agent 共用一个 token
+
+共享 token 意味着无法追责、无法单独回收。一个用途一个身份。
+
+### 3. 把 AI review 当成人工批准
+
+AI review 可以先扫一遍，但 Required approvals 必须由人完成。
+
+### 4. agent 分支没有命名约定
+
+没有统一前缀，审计、清理、Rulesets 限制都做不了。
+
+## 延伸阅读
+
+- [GitHub Docs: Risks and mitigations for Copilot cloud agent](https://docs.github.com/en/copilot/concepts/agents/cloud-agent/risks-and-mitigations)
+- [Rulesets](rulesets.md)
+- [Branch Protection](branch-protection.md)
+- [CODEOWNERS](codeowners.md)
+- [AI Reviewer 与 Human Reviewer](../05-ai-native-development/ai-reviewer-and-human-reviewer.md)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Therefore, v2.0 upgrades this repository into:
 5.  [Merge Queue](04-github-engineering/04-github-engineering_en/merge-queue_en.md)
 6.  [GitOps and Config as Code](04-github-engineering/04-github-engineering_en/gitops-and-config-as-code_en.md)
 7.  [Release Management](04-github-engineering/04-github-engineering_en/release-management_en.md)
+8.  [AI Agent Governance](04-github-engineering/04-github-engineering_en/ai-agent-governance_en.md)
 
 ### AI Native Development Path
 
@@ -106,6 +107,7 @@ Therefore, v2.0 upgrades this repository into:
 | AI changed too many files at once, don't know how to review | [AI Change Review Examples](05-ai-native-development/05-ai-native-development_en/ai-change-review-example_en.md) |
 | Large AI-generated diff needs to be split into commits or PRs | [AI Commit Splitting](05-ai-native-development/05-ai-native-development_en/ai-commit-splitting_en.md), [Stacked PR for AI-Generated Changes](05-ai-native-development/05-ai-native-development_en/stacked-pr-for-ai-generated-changes_en.md) |
 | Want to protect the main branch | [Branch Protection](04-github-engineering/04-github-engineering_en/branch-protection_en.md) |
+| AI agents are pushing code and opening PRs, and I don't know how to govern them | [AI Agent Governance](04-github-engineering/04-github-engineering_en/ai-agent-governance_en.md) |
 | Too many PRs, main branch often broken after merge | [Merge Queue](04-github-engineering/04-github-engineering_en/merge-queue_en.md) |
 | Clone, status, or checkout is slow in a large repository | [Large Repository Git Practices](07-large-repo/07-large-repo_en/large-repo-git-practices_en.md) |
 | Want to directly copy team templates | [Templates](08-templates/08-templates_en/README_en.md) |

--- a/README_zh.md
+++ b/README_zh.md
@@ -77,6 +77,7 @@ v2.0 版本的定位是：
 5. [Merge Queue](04-github-engineering/merge-queue.md)
 6. [GitOps and Config as Code](04-github-engineering/gitops-and-config-as-code.md)
 7. [发布管理](04-github-engineering/release-management.md)
+8. [AI Agent 治理](04-github-engineering/ai-agent-governance.md)
 
 ### AI Native 开发路径
 
@@ -106,6 +107,7 @@ v2.0 版本的定位是：
 | AI 一次改了很多文件，不知道怎么审 | [AI 变更审查实战样例](05-ai-native-development/ai-change-review-example.md) |
 | AI 生成的大 diff 需要拆 commit 或拆 PR | [AI Commit Splitting](05-ai-native-development/ai-commit-splitting.md)、[Stacked PR for AI-Generated Changes](05-ai-native-development/stacked-pr-for-ai-generated-changes.md) |
 | 想保护 main 分支 | [Branch Protection](04-github-engineering/branch-protection.md) |
+| AI agent 开始直接提交代码、发 PR，不知道怎么管 | [AI Agent 治理](04-github-engineering/ai-agent-governance.md) |
 | PR 很多，主分支经常被合坏 | [Merge Queue](04-github-engineering/merge-queue.md) |
 | 大仓库 clone、status、checkout 很慢 | [Large Repository Git Practices](07-large-repo/large-repo-git-practices.md) |
 | 想直接复制团队模板 | [Templates](08-templates/) |


### PR DESCRIPTION
## Summary

PR 1 of 4 in the v2.1.0 stack. Merge this one first.

Adds `04-github-engineering/ai-agent-governance.md` (zh + en) covering AI agents as governed repository participants: three identity models (local tools, platform-hosted agents, self-built automation), permission scoping via Rulesets branch targeting, PR approval rules, CI triggers with secrets isolation, traceability, a minimal setup list, and common mistakes. Adds navigation entries in the section README and root READMEs.

## AI involvement

- Tool: Claude Code
- Task boundary: new governance article plus navigation entries only
- Facts about Copilot cloud agent restrictions were verified against the official GitHub documentation: https://docs.github.com/en/copilot/concepts/agents/cloud-agent/risks-and-mitigations
- Suggested human review focus: the built-in restriction list in the hosted agent section, and the minimal setup recommendations

## Verification

- `python3 scripts/check-docs.py` passes (local links, forbidden text, tracked files)
- `python3 scripts/check-links.py --no-external` passes
- New external links manually verified to return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)