### PR TITLE
docs: add AGENTS.md template

### DIFF
--- a/04-github-engineering/04-github-engineering_en/ai-agent-governance_en.md
+++ b/04-github-engineering/04-github-engineering_en/ai-agent-governance_en.md
@@ -129,4 +129,5 @@ Without a unified prefix, auditing, cleanup, and Ruleset targeting all become im
 - [Rulesets](rulesets_en.md)
 - [Branch Protection](branch-protection_en.md)
 - [CODEOWNERS](codeowners_en.md)
+- [AGENTS.md Template](../../08-templates/08-templates_en/agents-md-template_en.md)
 - [AI Reviewer and Human Reviewer](../../05-ai-native-development/05-ai-native-development_en/ai-reviewer-and-human-reviewer_en.md)

--- a/04-github-engineering/ai-agent-governance.md
+++ b/04-github-engineering/ai-agent-governance.md
@@ -127,4 +127,5 @@ AI review 可以先扫一遍，但 Required approvals 必须由人完成。
 - [Rulesets](rulesets.md)
 - [Branch Protection](branch-protection.md)
 - [CODEOWNERS](codeowners.md)
+- [AGENTS.md 模板](../08-templates/agents-md-template.md)
 - [AI Reviewer 与 Human Reviewer](../05-ai-native-development/ai-reviewer-and-human-reviewer.md)

--- a/08-templates/08-templates_en/README_en.md
+++ b/08-templates/08-templates_en/README_en.md
@@ -12,10 +12,11 @@ This directory provides templates that can be copied into your team's repository
 | Small Teams | [Pull Request Template](pull-request-template_en.md), [Code Review Checklist](code-review-checklist_en.md) |
 | Growing Teams | PR Template, Review Checklist, Issue Template, Release Note |
 | Teams with Production Release Pressure | [Hotfix Process](hotfix-process_en.md), [Release Note Template](release-note-template_en.md) |
-| AI Programming Teams | [AI Code Review Checklist](ai-code-review-checklist_en.md), PR Template, Commit Message Convention |
+| AI Programming Teams | [AGENTS.md Template](agents-md-template_en.md), [AI Code Review Checklist](ai-code-review-checklist_en.md), PR Template, Commit Message Convention |
 
 ## Template List
 
+- [AGENTS.md Template](agents-md-template_en.md)
 - [Pull Request Template](pull-request-template_en.md)
 - [Code Review Checklist](code-review-checklist_en.md)
 - [AI Code Review Checklist](ai-code-review-checklist_en.md)

--- a/08-templates/08-templates_en/agents-md-template_en.md
+++ b/08-templates/08-templates_en/agents-md-template_en.md
@@ -1,0 +1,88 @@
+# AGENTS.md Template
+
+English | [中文](../agents-md-template.md)
+
+AGENTS.md is a project guide written for AI coding agents. It is an open format read by tools such as Codex, GitHub Copilot cloud agent, Devin, Cursor, Aider, and Gemini CLI. README is for humans; AGENTS.md is for agents: how to set up the environment, what to run after a change, and which areas must never be touched.
+
+Claude Code reads CLAUDE.md, which shares the same content structure. The two files can reference each other so you avoid maintaining two rule sets.
+
+## Where to Place It
+
+- One copy at the repository root.
+- In a monorepo, sub-projects can carry their own copy. Agents generally prioritize the file closest to the changed code.
+
+## Template
+
+```markdown
+# AGENTS.md
+
+## Project Overview
+
+One sentence on what this repository does, the tech stack, and service boundaries.
+
+## Environment Setup
+
+- Install dependencies: `pnpm install`
+- Start local server: `pnpm dev`
+
+## Required Verification After Changes
+
+- Unit tests: `pnpm test`
+- Type check: `pnpm typecheck`
+- Lint: `pnpm lint`
+
+Run at least the tests for the touched module; run the full suite when shared modules change.
+
+## Code Style
+
+- TypeScript strict mode.
+- Match the naming and comment density of the surrounding file.
+- Before adding a new dependency, check whether the repository already has one of the same kind.
+
+## Repository Structure
+
+- `src/api/`: external interface layer
+- `src/service/`: business logic
+- `src/infra/`: data access and external dependencies
+
+## Boundaries
+
+The following operations are forbidden:
+
+- Changing CI configuration under `.github/workflows/`
+- Changing historical database migration files
+- Deleting or rewriting existing test assertions to make tests pass
+- Force pushing to any shared branch
+- Writing `.env` contents, keys, or tokens into any file
+
+## Commit and PR Conventions
+
+- Branch naming: `ai/task-<topic>`
+- Commit format: `<type>(<scope>): <subject>`
+- Commits with AI involvement carry a trailer: `Co-authored-by: <tool> <email>`
+- The PR description states: task boundaries, files verified by a human, verification commands and results
+```
+
+## Writing Tips
+
+- Write executable commands, keep prose short. An agent can do nothing with "please keep the code clean" but can run `pnpm lint` directly.
+- Express constraints as allow and deny lists. The more specific, the more effective.
+- Keep verification commands identical to CI. What the agent runs locally is what CI will run.
+- Prune regularly. Outdated instructions keep misleading agents, which is worse than having none.
+- Keep it within one or two screens. Agents read it on every session, and length dilutes the key constraints.
+
+## Mapping to Tool-Specific Files
+
+| Tool | File Read |
+| --- | --- |
+| Codex, Devin, Cursor, Aider, Gemini CLI, etc. | `AGENTS.md` |
+| Claude Code | `CLAUDE.md`, which can reference AGENTS.md |
+| GitHub Copilot | `AGENTS.md`, also supports `.github/copilot-instructions.md` |
+
+For the supported tool list, refer to the official [agents.md](https://agents.md) page.
+
+## Extended Reading
+
+- [agents.md official guide](https://agents.md)
+- [Codex / Claude Code Git Practices](../../05-ai-native-development/05-ai-native-development_en/codex-claude-code-git-practices_en.md)
+- [AI Agent Governance](../../04-github-engineering/04-github-engineering_en/ai-agent-governance_en.md)

--- a/08-templates/README.md
+++ b/08-templates/README.md
@@ -12,10 +12,11 @@
 | 小团队 | [Pull Request Template](pull-request-template.md)、[Code Review Checklist](code-review-checklist.md) |
 | 成长期团队 | PR 模板、Review 清单、Issue 模板、Release Note |
 | 有生产发布压力的团队 | [Hotfix Process](hotfix-process.md)、[Release Note Template](release-note-template.md) |
-| AI 编程团队 | [AI Code Review Checklist](ai-code-review-checklist.md)、PR 模板、commit message 规范 |
+| AI 编程团队 | [AGENTS.md 模板](agents-md-template.md)、[AI Code Review Checklist](ai-code-review-checklist.md)、PR 模板、commit message 规范 |
 
 ## 模板列表
 
+- [AGENTS.md 模板](agents-md-template.md)
 - [Pull Request Template](pull-request-template.md)
 - [Code Review Checklist](code-review-checklist.md)
 - [AI Code Review Checklist](ai-code-review-checklist.md)

--- a/08-templates/agents-md-template.md
+++ b/08-templates/agents-md-template.md
@@ -1,0 +1,86 @@
+# AGENTS.md 模板
+
+AGENTS.md 是给 AI coding agent 看的项目说明文件，一个开放格式，Codex、GitHub Copilot cloud agent、Devin、Cursor、Aider、Gemini CLI 等工具都会读取。README 写给人看，AGENTS.md 写给 agent 看：环境怎么搭、改完跑什么验证、哪些地方不能动。
+
+Claude Code 读取的是 CLAUDE.md，内容结构相同，两份可以互相引用，避免维护两套规则。
+
+## 放置位置
+
+- 仓库根目录放一份
+- monorepo 可以在子项目目录再放一份，agent 一般优先读取离改动文件最近的那份
+
+## 模板
+
+```markdown
+# AGENTS.md
+
+## 项目概览
+
+一句话说清这个仓库做什么、技术栈、服务边界。
+
+## 环境准备
+
+- 安装依赖: `pnpm install`
+- 启动本地服务: `pnpm dev`
+
+## 改动后必须验证
+
+- 单元测试: `pnpm test`
+- 类型检查: `pnpm typecheck`
+- 代码检查: `pnpm lint`
+
+任何改动至少跑一次相关模块的测试，改公共模块时跑全量。
+
+## 代码风格
+
+- TypeScript strict 模式
+- 与所在文件保持一致的命名和注释密度
+- 引入新依赖前，先确认仓库里是否已有同类依赖
+
+## 仓库结构
+
+- `src/api/`: 对外接口层
+- `src/service/`: 业务逻辑
+- `src/infra/`: 数据访问与外部依赖
+
+## 边界约定
+
+禁止以下操作:
+
+- 修改 `.github/workflows/` 下的 CI 配置
+- 修改数据库 migration 历史文件
+- 删除或改写已有测试断言来让测试通过
+- force push 到任何共享分支
+- 把 `.env`、密钥、token 写进任何文件
+
+## 提交与 PR 约定
+
+- 分支命名: `ai/task-<topic>`
+- commit 格式: `<type>(<scope>): <subject>`
+- AI 参与的提交加 trailer: `Co-authored-by: <tool> <email>`
+- PR 描述写明: 任务边界、人工检查过的文件、验证命令和结果
+```
+
+## 写作建议
+
+- 写可执行命令，少写散文。agent 对“请保持代码整洁”无能为力，对 `pnpm lint` 能直接执行
+- 约束写成允许和禁止两张清单，越具体越有效
+- 验证命令和 CI 保持一致，agent 在本地跑的就是 CI 要跑的
+- 定期修剪。过时的指令会持续误导 agent，比没有指令更糟
+- 篇幅控制在一两屏内，agent 每次会话都要读它，太长会稀释关键约束
+
+## 和各工具配置文件的对应
+
+| 工具 | 读取文件 |
+| --- | --- |
+| Codex、Devin、Cursor、Aider、Gemini CLI 等 | `AGENTS.md` |
+| Claude Code | `CLAUDE.md`，可在其中引用 AGENTS.md |
+| GitHub Copilot | `AGENTS.md`，也支持 `.github/copilot-instructions.md` |
+
+工具支持范围以 [agents.md](https://agents.md) 官方列表为准。
+
+## 延伸阅读
+
+- [agents.md 官方说明](https://agents.md)
+- [Codex / Claude Code Git 实践](../05-ai-native-development/codex-claude-code-git-practices.md)
+- [AI Agent 治理](../04-github-engineering/ai-agent-governance.md)

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Therefore, v2.0 upgrades this repository into:
 | Large AI-generated diff needs to be split into commits or PRs | [AI Commit Splitting](05-ai-native-development/05-ai-native-development_en/ai-commit-splitting_en.md), [Stacked PR for AI-Generated Changes](05-ai-native-development/05-ai-native-development_en/stacked-pr-for-ai-generated-changes_en.md) |
 | Want to protect the main branch | [Branch Protection](04-github-engineering/04-github-engineering_en/branch-protection_en.md) |
 | AI agents are pushing code and opening PRs, and I don't know how to govern them | [AI Agent Governance](04-github-engineering/04-github-engineering_en/ai-agent-governance_en.md) |
+| Want an agent collaboration convention for the team repository | [AGENTS.md Template](08-templates/08-templates_en/agents-md-template_en.md) |
 | Too many PRs, main branch often broken after merge | [Merge Queue](04-github-engineering/04-github-engineering_en/merge-queue_en.md) |
 | Clone, status, or checkout is slow in a large repository | [Large Repository Git Practices](07-large-repo/07-large-repo_en/large-repo-git-practices_en.md) |
 | Want to directly copy team templates | [Templates](08-templates/08-templates_en/README_en.md) |

--- a/README_zh.md
+++ b/README_zh.md
@@ -108,6 +108,7 @@ v2.0 版本的定位是：
 | AI 生成的大 diff 需要拆 commit 或拆 PR | [AI Commit Splitting](05-ai-native-development/ai-commit-splitting.md)、[Stacked PR for AI-Generated Changes](05-ai-native-development/stacked-pr-for-ai-generated-changes.md) |
 | 想保护 main 分支 | [Branch Protection](04-github-engineering/branch-protection.md) |
 | AI agent 开始直接提交代码、发 PR，不知道怎么管 | [AI Agent 治理](04-github-engineering/ai-agent-governance.md) |
+| 想给团队仓库写一份 agent 协作约定 | [AGENTS.md 模板](08-templates/agents-md-template.md) |
 | PR 很多，主分支经常被合坏 | [Merge Queue](04-github-engineering/merge-queue.md) |
 | 大仓库 clone、status、checkout 很慢 | [Large Repository Git Practices](07-large-repo/large-repo-git-practices.md) |
 | 想直接复制团队模板 | [Templates](08-templates/) |


### PR DESCRIPTION
## Summary

PR 2 of 4 in the v2.1.0 stack, based on #57. Merge after #57.

Adds `08-templates/agents-md-template.md` (zh + en): a copyable AGENTS.md template with six sections (overview, environment setup, required verification, code style, boundaries, commit and PR conventions), writing tips, and a mapping table to tool-specific instruction files (CLAUDE.md, copilot-instructions). Also restores the cross-link from the governance guide to this template, and adds navigation entries.

## AI involvement

- Tool: Claude Code
- Task boundary: new template plus navigation entries and one cross-link
- Tool compatibility claims verified against the official https://agents.md page
- Suggested human review focus: whether the template's forbidden-operations list matches how your teams actually run agents

## Verification

- `python3 scripts/check-docs.py` passes
- `python3 scripts/check-links.py --no-external` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)