### PR TITLE
docs: expand multi-agent and stacked PR guides

### DIFF
--- a/00-meta/roadmap.md
+++ b/00-meta/roadmap.md
@@ -45,6 +45,16 @@ v2.0 先做一件事：建立清晰的内容结构，并完成第一批能直接
 - [x] 全仓库链接校验
 - [ ] 准备 `v2.0.0` release notes
 
+## v2.1.0：Agent 治理与协作约定
+
+v2.1.0 把 AI agent 当作仓库里的正式参与者来覆盖，补齐治理和约定层。
+
+- [x] 新增 `ai-agent-governance.md`，覆盖 bot 身份、权限、PR 审批、CI 触发、secrets 隔离
+- [x] 新增 AGENTS.md 模板，供团队仓库直接复制
+- [x] 本仓库落地自己的 AGENTS.md，贡献指南补充 AI 贡献规则
+- [x] `multi-agent-branch-strategy.md` 补齐对比、整合、清理的可执行流程
+- [x] `stacked-pr-for-ai-generated-changes.md` 补齐原生 git 命令和栈管理工具
+
 ## 内容原则
 
 1. 少堆链接，多讲判断

--- a/05-ai-native-development/05-ai-native-development_en/multi-agent-branch-strategy_en.md
+++ b/05-ai-native-development/05-ai-native-development_en/multi-agent-branch-strategy_en.md
@@ -7,18 +7,97 @@ When developing with multiple agents in parallel, the core is isolating tasks, c
 ## Branch Naming
 
 ```text
-ai/task-parser-refactor
-ai/task-api-test
-ai/review-parser-refactor
+ai/task-parser-refactor      # one clear task
+ai/experiment-parser-a       # approach A to the same problem
+ai/experiment-parser-b       # approach B to the same problem
+ai/review-parser-refactor    # cleanup branch prepared for review
+```
+
+Before merging experimental branches, reorganize them into normal business branches:
+
+```text
+feat/parser-error-handling
+fix/parser-empty-input
 ```
 
 ## Recommended Process
 
-1. One branch per agent.
-2. One clear task per branch.
+1. One branch per agent, paired with one worktree directory per branch.
+2. One clear task per branch, with boundaries cut along directories or modules.
 3. Independent commits and validation for each branch.
-4. Human selects which solutions to retain.
-5. Organize commits before merging.
+4. Humans compare the results and choose which solution to keep.
+5. Organize commits before merging, and rename the experimental branch into a business branch.
+
+## Comparing Experimental Branches
+
+Two agents each produced a solution. First check what each branch changed relative to the main line:
+
+```bash
+git log --oneline main..ai/experiment-parser-a
+git diff main...ai/experiment-parser-a    # three dots: only the branch's own changes
+git diff main...ai/experiment-parser-b
+```
+
+Then compare the two solutions directly:
+
+```bash
+git diff ai/experiment-parser-a..ai/experiment-parser-b
+git range-diff main ai/experiment-parser-a ai/experiment-parser-b
+```
+
+`git range-diff` aligns the two branches commit by commit, which works well when the two solutions have similar structure.
+
+Do not decide on diffs alone. Run the same test commands on both branches and record the results in the task notes or PR description as the basis for the decision.
+
+## Integrating the Winning Solution
+
+When solution A wins as a whole, turn it into a business branch:
+
+```bash
+git switch -c feat/parser-error-handling ai/experiment-parser-a
+git rebase main
+```
+
+When you only need part of solution B, pick by commit:
+
+```bash
+git cherry-pick <commit-sha>
+```
+
+Or pick by file:
+
+```bash
+git restore --source ai/experiment-parser-b -- src/parser/recover.ts
+git add src/parser/recover.ts
+git commit
+```
+
+## When Two Agents Touch the Same File
+
+Prevention first: cut task boundaries so agent scopes do not overlap, and let only one task touch files such as route tables, dependency manifests, and shared configuration.
+
+When a collision still happens, handle it in order:
+
+1. Merge one branch first.
+2. Rebase the other branch onto the latest main line: `git rebase main`.
+3. Conflicts are decided by humans. You can ask the agents to explain the intent of each side, but a human picks the outcome.
+4. After resolving conflicts, rerun the branch's validation before sending it to review.
+
+## Cleaning Up Losing Branches
+
+```bash
+# Tag first if you want to preserve the state for later reference
+git tag archive/ai-experiment-parser-b ai/experiment-parser-b
+
+# Delete the local branch and its worktree
+git branch -D ai/experiment-parser-b
+git worktree remove ../wt-parser-b
+
+# If it was pushed, delete the remote branch as well
+git push origin --delete ai/experiment-parser-b
+```
+
+When closing the draft PR of a losing branch, state why it lost, so similar future tasks have a record to consult.
 
 ## Avoid
 
@@ -26,25 +105,13 @@ ai/review-parser-refactor
 - Multiple agents modifying the same set of files simultaneously.
 - Letting agents merge public branches themselves.
 - Accepting results without looking at the diff.
-
-## Recommended Naming
-
-```text
-ai/experiment-parser-a
-ai/experiment-parser-b
-ai/review-parser-a
-```
-
-Before merging experimental branches, it is suggested to reorganize them into normal business branches:
-
-```text
-feat/parser-error-handling
-fix/parser-empty-input
-```
+- Leaving experimental branches uncleaned until the repository fills up with dead `ai/` branches.
 
 ## Extended Reading
 
 - [git worktree](https://git-scm.com/docs/git-worktree)
+- [git range-diff](https://git-scm.com/docs/git-range-diff)
 - [Worktree for AI Agents](worktree-for-ai-agents_en.md)
 - [AI Native Git Workflow](ai-native-git-workflow_en.md)
+- [AI Agent Governance](../../04-github-engineering/04-github-engineering_en/ai-agent-governance_en.md)
 - [Recommended Reading Index](../../09-resources/09-resources_en/recommended-reading_en.md)

--- a/05-ai-native-development/05-ai-native-development_en/stacked-pr-for-ai-generated-changes_en.md
+++ b/05-ai-native-development/05-ai-native-development_en/stacked-pr-for-ai-generated-changes_en.md
@@ -87,7 +87,68 @@ Suitable for AI refactoring or incident fixes.
 - Merge order must be clear.
 - Rollback prioritized from top of the stack downwards.
 
-## 5. Relationship with Commit Splitting
+## 5. Operating a Stack with Native Git
+
+Create a two-level stack:
+
+```bash
+git switch -c pr-1 main
+# commit the content of pr-1
+git switch -c pr-2 pr-1
+# commit the content of pr-2
+
+gh pr create --base main --head pr-1
+gh pr create --base pr-1 --head pr-2
+```
+
+The downstream PR's base points to the upstream branch, so reviewers only see `pr-2`'s own changes in `pr-2`.
+
+Update downstream after upstream changes:
+
+```bash
+git switch pr-2
+git rebase pr-1
+git push --force-with-lease origin pr-2
+```
+
+For deeper stacks, update the whole chain at once from the top (Git 2.38+):
+
+```bash
+git switch pr-3
+git rebase main --update-refs
+git push --force-with-lease origin pr-1 pr-2 pr-3
+```
+
+`--update-refs` moves the pointers of the other branches in the stack during the rebase, so you skip the per-level manual rebase.
+
+After `pr-1` merges into the main line, remove the already-merged commits from `pr-2`'s history:
+
+```bash
+git switch pr-2
+git rebase --onto main pr-1
+git push --force-with-lease origin pr-2
+```
+
+GitHub automatically retargets the downstream PR's base to `main` after the base branch is deleted, but the rebase is still on you.
+
+Risk note: force push only your own stack branches, always with `--force-with-lease`, and never force push the main branch.
+
+## 6. Stack Management Tools
+
+When the stack grows beyond two or three levels, or several people on the team work with stacks, bring in tooling to replace manual rebasing. Taking the Graphite CLI as an example:
+
+```bash
+gt create -am "add tests"    # create a new stack branch on top of the current one
+gt modify -a                 # amend the current branch and restack the branches above
+gt submit --stack            # push the whole chain and create or update PRs
+gt sync                      # pull the main line, clean up merged branches, restack
+```
+
+Sapling's ReviewStack offers a similar stack-oriented review view.
+
+Learn the mechanics with native commands first, then decide whether to adjust the team workflow around a tool.
+
+## 7. Relationship with Commit Splitting
 
 Commit splitting is suitable for keeping history clear within a PR.
 
@@ -102,7 +163,7 @@ stacked PR
 
 Meta Sapling's public practice indicates that commit stacks are suitable for expressing a set of continuous small changes. After AI generates a large diff, you can borrow this idea to transform "large chunks of results" into "reviewable sequences of changes." For more case comparisons, see [Enterprise Git Workflow Stack Decision Map](../../10-company-practices/10-company-practices_en/company-practices-decision-map_en.md).
 
-## 6. Suitable Scenarios
+## 8. Suitable Scenarios
 
 Suitable for:
 
@@ -120,6 +181,8 @@ Not suitable for:
 
 ## Extended Reading
 
+- [git rebase documentation](https://git-scm.com/docs/git-rebase)
+- [Graphite CLI Command Cheatsheet](https://graphite.dev/docs/cheatsheet)
 - [Meta Sapling and Stacked Commits Practice](../../10-company-practices/10-company-practices_en/meta-sapling-stacked-commits_en.md)
 - [Google Code Review Practice](../../10-company-practices/10-company-practices_en/google-code-review_en.md)
 - [Enterprise Git Workflow Stack Decision Map](../../10-company-practices/10-company-practices_en/company-practices-decision-map_en.md)

--- a/05-ai-native-development/multi-agent-branch-strategy.md
+++ b/05-ai-native-development/multi-agent-branch-strategy.md
@@ -5,18 +5,97 @@
 ## 分支命名
 
 ```text
-ai/task-parser-refactor
-ai/task-api-test
-ai/review-parser-refactor
+ai/task-parser-refactor      # 单一明确任务
+ai/experiment-parser-a       # 同一问题的方案 A
+ai/experiment-parser-b       # 同一问题的方案 B
+ai/review-parser-refactor    # 给 Review 用的整理分支
+```
+
+实验分支合入前，整理成正常业务分支：
+
+```text
+feat/parser-error-handling
+fix/parser-empty-input
 ```
 
 ## 推荐流程
 
-1. 每个 Agent 一个分支
-2. 每个分支一个明确任务
+1. 每个 Agent 一个分支，配合 worktree 一个分支一个目录
+2. 每个分支一个明确任务，边界按目录或模块切分
 3. 每个分支独立提交和验证
-4. 人类选择需要保留的方案
-5. 合并前整理 commit
+4. 人类对比结果，选择保留的方案
+5. 合并前整理 commit，实验分支重命名为业务分支
+
+## 对比多个实验分支
+
+两个 Agent 各自做了一版方案，先分别看每个分支相对主线改了什么：
+
+```bash
+git log --oneline main..ai/experiment-parser-a
+git diff main...ai/experiment-parser-a    # 三个点：只看分支自己的改动
+git diff main...ai/experiment-parser-b
+```
+
+再直接对比两个方案：
+
+```bash
+git diff ai/experiment-parser-a..ai/experiment-parser-b
+git range-diff main ai/experiment-parser-a ai/experiment-parser-b
+```
+
+`git range-diff` 按 commit 对齐两个分支，适合两个方案结构接近时逐个提交看差异。
+
+对比不能只看 diff。两个分支用同样的命令各跑一遍测试，把结果记进任务说明或 PR 描述，作为选型依据。
+
+## 整合胜出方案
+
+方案 A 整体胜出时，把它整理成业务分支：
+
+```bash
+git switch -c feat/parser-error-handling ai/experiment-parser-a
+git rebase main
+```
+
+只需要方案 B 里的局部成果时，按 commit 捡：
+
+```bash
+git cherry-pick <commit-sha>
+```
+
+或者按文件捡：
+
+```bash
+git restore --source ai/experiment-parser-b -- src/parser/recover.ts
+git add src/parser/recover.ts
+git commit
+```
+
+## 两个 Agent 改了同一个文件
+
+预防优先：切分任务时就避免两个 Agent 的范围重叠，路由表、依赖清单、公共配置这类文件尽量只让一个任务碰。
+
+真撞上时按顺序处理：
+
+1. 先合入其中一个分支
+2. 另一个分支 rebase 到最新主线：`git rebase main`
+3. 冲突由人决策。可以让 Agent 解释两边各自的意图，最终采用哪边由人决定
+4. 解完冲突重新跑该分支的验证，再进 Review
+
+## 清理落选分支
+
+```bash
+# 需要保留现场时，先打归档 tag
+git tag archive/ai-experiment-parser-b ai/experiment-parser-b
+
+# 删除本地分支和对应 worktree
+git branch -D ai/experiment-parser-b
+git worktree remove ../wt-parser-b
+
+# 推送过远端的话，同时删除远端分支
+git push origin --delete ai/experiment-parser-b
+```
+
+落选分支对应的 draft PR 关闭时写明落选原因，下次做同类任务时有据可查。
 
 ## 避免
 
@@ -24,25 +103,13 @@ ai/review-parser-refactor
 - 多个 Agent 同时改同一组文件
 - 让 Agent 自行合并公共分支
 - 没看 diff 就接受结果
-
-## 推荐命名
-
-```text
-ai/experiment-parser-a
-ai/experiment-parser-b
-ai/review-parser-a
-```
-
-实验分支合入前，建议整理成正常业务分支：
-
-```text
-feat/parser-error-handling
-fix/parser-empty-input
-```
+- 实验分支长期不清理，仓库里堆满 `ai/` 死分支
 
 ## 延伸阅读
 
 - [git worktree](https://git-scm.com/docs/git-worktree)
+- [git range-diff](https://git-scm.com/docs/git-range-diff)
 - [Worktree for AI Agents](worktree-for-ai-agents.md)
 - [AI Native Git Workflow](ai-native-git-workflow.md)
+- [AI Agent 治理](../04-github-engineering/ai-agent-governance.md)
 - [推荐阅读索引](../09-resources/recommended-reading.md)

--- a/05-ai-native-development/stacked-pr-for-ai-generated-changes.md
+++ b/05-ai-native-development/stacked-pr-for-ai-generated-changes.md
@@ -85,7 +85,68 @@ test only -> refactor no behavior change -> behavior change -> cleanup
 - 合入顺序要明确
 - 回滚时优先从栈顶向下处理
 
-## 5. 和 commit 拆分的关系
+## 5. 用原生 git 操作一个栈
+
+创建一个两层的栈：
+
+```bash
+git switch -c pr-1 main
+# 提交 pr-1 的内容
+git switch -c pr-2 pr-1
+# 提交 pr-2 的内容
+
+gh pr create --base main --head pr-1
+gh pr create --base pr-1 --head pr-2
+```
+
+下游 PR 的 base 指向上游分支，reviewer 在 `pr-2` 里只会看到 `pr-2` 自己的改动。
+
+上游改动后更新下游：
+
+```bash
+git switch pr-2
+git rebase pr-1
+git push --force-with-lease origin pr-2
+```
+
+栈比较深时，在栈顶一次更新整串（Git 2.38+）：
+
+```bash
+git switch pr-3
+git rebase main --update-refs
+git push --force-with-lease origin pr-1 pr-2 pr-3
+```
+
+`--update-refs` 会在 rebase 的同时移动栈里其他分支的指针，省去逐层手工 rebase。
+
+`pr-1` 合入主线后，把已合入的提交从 `pr-2` 的历史里去掉：
+
+```bash
+git switch pr-2
+git rebase --onto main pr-1
+git push --force-with-lease origin pr-2
+```
+
+GitHub 会在 base 分支删除后自动把下游 PR 的 base 改回 `main`，rebase 仍然要自己完成。
+
+风险提示：force push 只用于自己的栈分支，必须带 `--force-with-lease`，主分支永远禁止 force push。
+
+## 6. 栈管理工具
+
+栈深超过两三层，或者团队多人都在用栈时，建议引入工具代替手工 rebase。以 Graphite CLI 为例：
+
+```bash
+gt create -am "add tests"    # 在当前分支之上创建新的栈分支
+gt modify -a                 # 修改当前分支，自动 restack 上层分支
+gt submit --stack            # 整串推送并创建或更新 PR
+gt sync                      # 拉取主线、清理已合并分支、restack
+```
+
+Sapling 的 ReviewStack 提供类似的栈式 Review 视图。
+
+建议先用原生命令理解栈的原理，再决定要不要为工具调整团队工作流。
+
+## 7. 和 commit 拆分的关系
 
 commit 拆分适合一个 PR 内部保持历史清楚。
 
@@ -100,7 +161,7 @@ stacked PR
 
 Meta Sapling 的公开实践说明，提交栈适合表达一组连续小变更。AI 生成大 diff 后，可以借鉴这个思路，把“大块结果”改造成“可审查的变更序列”。更多案例对照见 [大厂工程实践决策图谱](../10-company-practices/company-practices-decision-map.md)。
 
-## 6. 适合什么场景
+## 8. 适合什么场景
 
 适合：
 
@@ -118,6 +179,8 @@ Meta Sapling 的公开实践说明，提交栈适合表达一组连续小变更�
 
 ## 延伸阅读
 
+- [git rebase 官方文档](https://git-scm.com/docs/git-rebase)
+- [Graphite CLI Command Cheatsheet](https://graphite.dev/docs/cheatsheet)
 - [Meta Sapling 与堆叠提交实践](../10-company-practices/meta-sapling-stacked-commits.md)
 - [Google Code Review 实践](../10-company-practices/google-code-review.md)
 - [大厂工程实践决策图谱](../10-company-practices/company-practices-decision-map.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,6 +31,16 @@ The v2.0.1 maintenance release focuses on open source project governance and mai
 - [x] Keep documentation checks active
 - [ ] Open public roadmap issues for upcoming maintenance work
 
+## v2.1.0
+
+The v2.1.0 release focuses on agent governance and agent-facing conventions, so the handbook covers AI agents as first-class repository participants.
+
+- [x] Add an AI agent governance guide covering bot identity, permissions, PR approval, CI triggers, and secrets isolation
+- [x] Add an AGENTS.md template for team repositories
+- [x] Add this repository's own AGENTS.md and AI contribution guidelines
+- [x] Expand the multi-agent branch strategy guide with executable comparison, integration, and cleanup workflows
+- [x] Expand the stacked PR guide with native Git commands and stack tooling
+
 ## Next Maintenance Areas
 
 ### Documentation Quality


### PR DESCRIPTION
## Summary

PR 4 of 4 in the v2.1.0 stack. Merge last.

Expands two guides from principle lists into executable workflows:

- `multi-agent-branch-strategy.md` (zh + en): comparing experiment branches (`git diff main...`, `git range-diff`), integrating the winning solution (cherry-pick by commit or by file), an ordered procedure for same-file collisions, and cleanup of losing branches (archive tag, branch, worktree, remote)
- `stacked-pr-for-ai-generated-changes.md` (zh + en): operating a stack with native Git (`gh pr create --base`, `git rebase --update-refs`, `git rebase --onto` after the base merges, `--force-with-lease` risk note) and Graphite CLI core commands
- Records the v2.1.0 scope in `ROADMAP.md` and `00-meta/roadmap.md`

## AI involvement

- Tool: Claude Code
- Task boundary: the two articles above plus roadmap entries, no other articles touched
- Graphite CLI command names verified against the official docs; a 404 link found during verification was corrected to https://graphite.dev/docs/cheatsheet
- Suggested human review focus: the `git rebase --onto main pr-1` sequence in section 5, since readers will copy it verbatim

## Verification

- `python3 scripts/check-docs.py` passes
- `python3 scripts/check-links.py --no-external` passes
- New external links manually verified to return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)