### PR TITLE
docs: 新增 Git 快照与状态心智模型样板

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -20,3 +20,6 @@ jobs:
 
       - name: Run docs checks
         run: python scripts/check-docs.py
+
+      - name: Run Git mental model labs
+        run: bash labs/git-mental-model/01-snapshots-and-state/test.sh

--- a/01-getting-started/01-getting-started_en/git-learning-path_en.md
+++ b/01-getting-started/01-getting-started_en/git-learning-path_en.md
@@ -17,13 +17,15 @@ working tree -> index -> local repository -> remote repository
 Recommended reading:
 
 1. [Git Mental Model](git-mental-model_en.md)
-2. [Git Basic Commands](git-basic-commands_en.md)
-3. [Why Use Git](why-git_en.md)
+2. [Snapshots and State: HEAD, Index, and Working Tree](git-mental-model-01-snapshots_en.md)
+3. [Git Basic Commands](git-basic-commands_en.md)
+4. [Why Use Git](why-git_en.md)
 
 Mastery Goals:
 
 - Understand `git status`.
 - Know the relationship between `git add` and `git commit`.
+- Distinguish different versions in HEAD, the index, and the working tree.
 - Know the difference between local commit and remote push.
 
 ## Phase 2: Daily Development

--- a/01-getting-started/01-getting-started_en/git-mental-model-01-snapshots_en.md
+++ b/01-getting-started/01-getting-started_en/git-mental-model-01-snapshots_en.md
@@ -1,0 +1,286 @@
+# Git Mental Model 01: Snapshots and State
+
+English | [中文](../git-mental-model-01-snapshots.md) | [Interactive demo](../../interactive/git-mental-model/snapshots-and-state.html) | [Runnable lab](../../labs/git-mental-model/01-snapshots-and-state/README.md)
+
+When an AI agent says that a change is complete, you still need to ask one question: is the change only in the working tree, staged in the index, or already recorded in a commit?
+
+These three locations can hold three versions of the same file at the same time. This model explains exactly what `git add`, `git commit`, `git diff`, and `git restore` affect.
+
+## The model in one view
+
+```text
+HEAD snapshot         Index snapshot        Working Tree
+current commit        next commit draft     files on disk
+version=1             version=2             version=3
+```
+
+- `HEAD` points to the currently checked-out commit, which records a project snapshot.
+- The index, also called the staging area, holds the snapshot proposed for the next commit.
+- The working tree is the current state of files on disk.
+- An untracked file belongs to neither the index nor a commit until it is added.
+
+`git commit` takes its input from the index. Unstaged working-tree content does not enter that commit.
+
+## Git records snapshots and presents differences
+
+In the user-facing logical model, each commit records a snapshot of the project. `git diff` computes the difference between two states and shows what changed between them.
+
+Git may use delta compression inside packfiles to save storage. That implementation detail does not change the snapshot model represented by a commit.
+
+The three common comparisons are:
+
+```text
+HEAD -------- git diff --cached --------> Index
+Index ----------- git diff -------------> Working Tree
+HEAD ------------ git diff HEAD --------> Working Tree
+```
+
+| Command | Compared states | Main question |
+| --- | --- | --- |
+| `git diff` | Index and working tree | What has not been staged yet? |
+| `git diff --cached` | HEAD and index | What will the next commit record? |
+| `git diff HEAD` | HEAD and working tree | What is the total tracked change from the current commit? |
+
+## Interactive demo
+
+[Open the Snapshots and State interactive](../../interactive/git-mental-model/snapshots-and-state.html). Step through edit, stage, edit again, and commit to see how `app.txt` changes across all three locations.
+
+To view it through a local static server, run this command from the repository root:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then visit:
+
+```text
+http://localhost:8000/interactive/git-mental-model/snapshots-and-state.html
+```
+
+Press `Ctrl-C` in the server terminal when you are finished.
+
+## Run the experiment in a temporary repository
+
+This experiment creates a new temporary repository and does not modify the current project.
+
+### Create the first snapshot
+
+```bash
+lab_dir=$(mktemp -d "${TMPDIR:-/tmp}/my-git-snapshots.XXXXXX")
+git -c init.defaultBranch=main init -q "$lab_dir"
+cd "$lab_dir"
+git config user.name "My Git Lab"
+git config user.email "lab@example.com"
+
+printf 'version=1\n' > app.txt
+git add app.txt
+git commit -q -m "record version 1"
+git status --short
+```
+
+Expected output: no output, because HEAD, the index, and the working tree match.
+
+### Change only the working tree
+
+```bash
+printf 'version=2\n' > app.txt
+git status --short
+```
+
+Expected output:
+
+```text
+ M app.txt
+```
+
+The first column represents the index and the second represents the working tree. The blank first column and `M` in the second mean that only the working tree has changed.
+
+```text
+HEAD=version=1    Index=version=1    Working Tree=version=2
+```
+
+### Put version=2 in the index
+
+```bash
+git add app.txt
+git status --short
+```
+
+Expected output:
+
+```text
+M  app.txt
+```
+
+The `M` moves to the first column. The index differs from HEAD, while the working tree matches the index.
+
+```text
+HEAD=version=1    Index=version=2    Working Tree=version=2
+```
+
+### Edit again after staging
+
+```bash
+printf 'version=3\n' > app.txt
+git status --short
+```
+
+Expected output:
+
+```text
+MM app.txt
+```
+
+The file now has three simultaneous versions. Read each location directly:
+
+```bash
+git show HEAD:app.txt
+git show :app.txt
+cat app.txt
+```
+
+The expected outputs, in order, are:
+
+```text
+version=1
+version=2
+version=3
+```
+
+The `:app.txt` syntax reads `app.txt` from the index.
+
+### Commit the index snapshot
+
+```bash
+git commit -m "record version 2"
+git status --short
+```
+
+The object ID in the commit output varies by environment. Its normalized form is:
+
+```text
+[main <object-id>] record version 2
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+```
+
+The following `git status --short` still shows:
+
+```text
+ M app.txt
+```
+
+Final state:
+
+```text
+HEAD=version=2    Index=version=2    Working Tree=version=3
+```
+
+The commit recorded version=2 from the index. Version=3 remains as an uncommitted working-tree edit.
+
+## A misleading inspection path
+
+After staging, this command may produce no output:
+
+```bash
+git diff
+```
+
+That result only means that the working tree matches the index. It does not prove that the repository has no changes. Continue with:
+
+```bash
+git diff --cached
+git status --short
+```
+
+When an agent or a person reports that there is no diff, the report should identify which comparison was run.
+
+## Recovery case: deleting a tracked working-tree file
+
+If tracked `app.txt` was deleted only from the working tree, inspect the state first:
+
+```bash
+git status --short
+git diff -- app.txt
+```
+
+After confirming that the deletion can be discarded, restore the file from HEAD:
+
+```bash
+git restore --source=HEAD --worktree -- app.txt
+git status --short
+```
+
+`git restore` overwrites the working-tree state for the selected path. Confirm that the current edit is disposable before running it.
+
+Git cannot recover an untracked file that was never added, committed, or saved by another tool. Understanding that boundary matters more than memorizing a recovery command.
+
+## Common misconceptions
+
+### "A commit records every modified file on disk"
+
+A commit records the index. Unstaged working-tree content remains on disk.
+
+### "No output from `git diff` means there are no changes"
+
+By default, `git diff` compares the index with the working tree. Use `git diff --cached` to inspect staged changes.
+
+### "Git only stores each change as a delta"
+
+Git presents commits as snapshots. A diff is a comparison result, while packfiles may use delta compression internally.
+
+### "Any file inside a Git repository can be recovered"
+
+Recovery requires content recorded in Git objects, the index, a stash, or another backup. Git has no recovery source for untracked content that was never saved.
+
+## Why this matters for AI agents
+
+After completing a task, an agent should distinguish these forms of evidence:
+
+| Fact to confirm | Inspection |
+| --- | --- |
+| Unstaged working-tree changes | `git diff` |
+| Snapshot proposed by the index | `git diff --cached` |
+| All tracked changes from HEAD | `git diff HEAD` |
+| Untracked, staged, or mixed states | `git status --short` |
+| Content of the latest commit | `git show --stat --oneline HEAD` |
+
+Practical rules:
+
+- Do not report generated files as committed changes.
+- Do not treat an empty `git diff` as a substitute for `git diff --cached` and `git status`.
+- Inspect paths before staging and avoid an unnecessarily broad `git add -A`.
+- Without commit authorization, verify and report state without creating a commit.
+- Before recovery, determine whether the content ever entered the index, a commit, a stash, or another backup.
+
+## Check your understanding
+
+<details>
+<summary>Why can <code>git status --short</code> show <code>MM app.txt</code>?</summary>
+
+The index differs from HEAD, and the working tree also differs from the index.
+
+</details>
+
+<details>
+<summary>Which version is committed from the <code>MM app.txt</code> state?</summary>
+
+Git commits the index version. In this experiment, that is version=2.
+
+</details>
+
+<details>
+<summary>Can reflog recover a deleted untracked file that was never staged?</summary>
+
+No. Reflog records ref updates and has no recorded content for a file that never entered Git.
+
+</details>
+
+## Further reading
+
+- [Pro Git: What is Git?](https://git-scm.com/book/en/v2/Getting-Started-What-is-Git%3F)
+- [Git User Manual: history and snapshots](https://git-scm.com/docs/user-manual)
+- [`git diff` documentation](https://git-scm.com/docs/git-diff)
+- [`git status` documentation](https://git-scm.com/docs/git-status)
+- [`git commit` documentation](https://git-scm.com/docs/git-commit)
+- [`git restore` documentation](https://git-scm.com/docs/git-restore)
+- [Git Mental Model overview](git-mental-model_en.md)

--- a/01-getting-started/01-getting-started_en/git-mental-model_en.md
+++ b/01-getting-started/01-getting-started_en/git-mental-model_en.md
@@ -2,6 +2,16 @@
 
 English | [中文](../git-mental-model.md)
 
+This page is the entry point to the Git Mental Model series. The four-area model is useful for quick operational decisions. The deeper series explains why Git behaves this way through snapshots, objects, refs, and history transformations.
+
+## Flagship series
+
+1. [Snapshots and State: HEAD, Index, and Working Tree](git-mental-model-01-snapshots_en.md)
+
+The first chapter uses three versions of one file to show what `git add` and `git commit` actually record. It includes an [interactive demo](../../interactive/git-mental-model/snapshots-and-state.html) and a [runnable lab](../../labs/git-mental-model/01-snapshots-and-state/README.md).
+
+## Four-area quick model
+
 To understand Git, first understand the four areas:
 
 ```text
@@ -58,7 +68,7 @@ Determine which area the file is in first before choosing a command, and errors 
 | `git add` | Working tree -> Index |
 | `git commit` | Index -> Local repository |
 | `git restore` | Discard or restore working tree content |
-| `git restore --staged` | Index -> Working tree |
+| `git restore --staged` | Restore the index from `HEAD` by default; keep the working tree unchanged |
 | `git push` | Local repository -> Remote repository |
 | `git fetch` | Remote repository -> Local remote reference |
 | `git pull` | fetch + merge or fetch + rebase |

--- a/01-getting-started/git-learning-path.md
+++ b/01-getting-started/git-learning-path.md
@@ -15,13 +15,15 @@ Git 不适合靠背命令学习。
 建议阅读：
 
 1. [Git 心智模型](git-mental-model.md)
-2. [Git 基础命令](git-basic-commands.md)
-3. [为什么使用 Git](why-git.md)
+2. [快照与状态：HEAD、Index 与 Working Tree](git-mental-model-01-snapshots.md)
+3. [Git 基础命令](git-basic-commands.md)
+4. [为什么使用 Git](why-git.md)
 
 掌握目标：
 
 - 看懂 `git status`
 - 知道 `git add` 和 `git commit` 的关系
+- 能区分 HEAD、Index 和 Working Tree 中的不同版本
 - 知道本地 commit 和远端 push 的区别
 
 ## 第二阶段：日常开发

--- a/01-getting-started/git-mental-model-01-snapshots.md
+++ b/01-getting-started/git-mental-model-01-snapshots.md
@@ -1,0 +1,288 @@
+# Git 心智模型 01：快照与状态
+
+[English](01-getting-started_en/git-mental-model-01-snapshots_en.md) | [交互演示](../interactive/git-mental-model/snapshots-and-state.html) | [可运行实验](../labs/git-mental-model/01-snapshots-and-state/README.md)
+
+当 AI Agent 回复“已经改完”，你还需要确认一件事：这些改动位于 Working Tree、Index，还是已经进入 commit？
+
+这三个位置可以同时保存同一个文件的三个版本。理解这一点，就能准确判断 `git add`、`git commit`、`git diff` 和 `git restore` 会影响什么。
+
+## 先看结论
+
+```text
+HEAD snapshot         Index snapshot        Working Tree
+current commit        next commit draft     files on disk
+version=1             version=2             version=3
+```
+
+- `HEAD` 指向当前检出的 commit，该 commit 记录一个项目快照。
+- Index 也叫 staging area，保存下一次 commit 准备记录的快照。
+- Working Tree 是磁盘上正在编辑的文件状态。
+- 未跟踪文件在执行 `git add` 前，不属于 Index 或任何 commit。
+
+`git commit` 的输入来自 Index。Working Tree 中尚未暂存的内容不会进入这次 commit。
+
+## Git 保存快照，也展示差异
+
+从使用者的逻辑模型看，每个 commit 记录项目在某个时刻的快照。`git diff` 根据两个状态计算差异，让你看到快照之间发生了什么。
+
+Git 的底层存储可能在 packfile 中使用 delta compression 节省空间，但这种存储优化不会改变 commit 表达项目快照的心智模型。
+
+三个常用比较方向：
+
+```text
+HEAD -------- git diff --cached --------> Index
+Index ----------- git diff -------------> Working Tree
+HEAD ------------ git diff HEAD --------> Working Tree
+```
+
+| 命令 | 比较的状态 | 主要回答 |
+| --- | --- | --- |
+| `git diff` | Index 与 Working Tree | 还有哪些改动没有暂存 |
+| `git diff --cached` | HEAD 与 Index | 下一次 commit 会记录什么 |
+| `git diff HEAD` | HEAD 与 Working Tree | 当前文件相对 commit 总共改了什么 |
+
+## 交互演示
+
+[打开“快照与状态”交互演示](../interactive/git-mental-model/snapshots-and-state.html)，依次执行“编辑、暂存、再次编辑、提交”，观察三个位置中 `app.txt` 的版本变化。
+
+直接在本地浏览器查看时，可以从仓库根目录启动静态服务器：
+
+```bash
+python3 -m http.server 8000
+```
+
+然后访问：
+
+```text
+http://localhost:8000/interactive/git-mental-model/snapshots-and-state.html
+```
+
+查看完成后，在运行服务器的终端按 `Ctrl-C` 退出。
+
+## 在临时仓库运行实验
+
+下面的实验不会修改当前项目。它会创建一个新的临时仓库。
+
+### 1. 创建第一个快照
+
+```bash
+lab_dir=$(mktemp -d "${TMPDIR:-/tmp}/my-git-snapshots.XXXXXX")
+git -c init.defaultBranch=main init -q "$lab_dir"
+cd "$lab_dir"
+git config user.name "My Git Lab"
+git config user.email "lab@example.com"
+
+printf 'version=1\n' > app.txt
+git add app.txt
+git commit -q -m "record version 1"
+git status --short
+```
+
+预期输出：没有输出，表示 HEAD、Index 和 Working Tree 内容一致。
+
+### 2. 只修改 Working Tree
+
+```bash
+printf 'version=2\n' > app.txt
+git status --short
+```
+
+预期输出：
+
+```text
+ M app.txt
+```
+
+左侧第一列表示 Index，右侧第二列表示 Working Tree。这里第一列为空、第二列是 `M`，说明改动只存在于 Working Tree。
+
+此时：
+
+```text
+HEAD=version=1    Index=version=1    Working Tree=version=2
+```
+
+### 3. 把 version=2 放入 Index
+
+```bash
+git add app.txt
+git status --short
+```
+
+预期输出：
+
+```text
+M  app.txt
+```
+
+`M` 移到第一列，表示 Index 相对 HEAD 已经改变，Working Tree 与 Index 一致。
+
+```text
+HEAD=version=1    Index=version=2    Working Tree=version=2
+```
+
+### 4. 暂存后再次编辑
+
+```bash
+printf 'version=3\n' > app.txt
+git status --short
+```
+
+预期输出：
+
+```text
+MM app.txt
+```
+
+现在同一个文件同时有三个版本。直接读取三个位置：
+
+```bash
+git show HEAD:app.txt
+git show :app.txt
+cat app.txt
+```
+
+预期输出依次是：
+
+```text
+version=1
+version=2
+version=3
+```
+
+其中 `:app.txt` 表示读取 Index 中的 `app.txt`。
+
+### 5. 提交 Index 中的快照
+
+```bash
+git commit -m "record version 2"
+git status --short
+```
+
+commit 输出中的对象 ID 会因环境而变化，可以把它规范化理解为：
+
+```text
+[main <object-id>] record version 2
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+```
+
+随后 `git status --short` 仍会显示：
+
+```text
+ M app.txt
+```
+
+最终状态：
+
+```text
+HEAD=version=2    Index=version=2    Working Tree=version=3
+```
+
+这证明 commit 记录了 Index 中的 version=2。稍后写入 Working Tree 的 version=3 仍然没有提交。
+
+## 一条容易误判的检查路径
+
+暂存以后执行：
+
+```bash
+git diff
+```
+
+可能没有任何输出。这只能说明 Working Tree 与 Index 一致，不能证明仓库没有改动。继续检查：
+
+```bash
+git diff --cached
+git status --short
+```
+
+因此，Agent 或人类在汇报“没有 diff”时，还应明确执行的是哪一种 diff。
+
+## 故障恢复：误删 Working Tree 文件
+
+如果 `app.txt` 已经被 Git 跟踪，并且只在 Working Tree 中误删，先检查：
+
+```bash
+git status --short
+git diff -- app.txt
+```
+
+确认需要丢弃这次删除后，从 HEAD 恢复：
+
+```bash
+git restore --source=HEAD --worktree -- app.txt
+git status --short
+```
+
+`git restore` 会覆盖 Working Tree 中对应路径的状态。执行前必须确认当前改动确实可以丢弃。
+
+Git 无法恢复从未被 `git add`、commit 或其他工具保存过的未跟踪文件。这个边界比恢复命令本身更重要。
+
+## 常见误解
+
+### “commit 会记录磁盘上的全部修改”
+
+commit 记录 Index。未暂存的 Working Tree 内容仍留在磁盘上。
+
+### “`git diff` 没输出就代表没有改动”
+
+`git diff` 默认只比较 Index 与 Working Tree。已暂存改动要用 `git diff --cached` 检查。
+
+### “Git 只保存每次修改的增量”
+
+Git 对外呈现 commit 快照。差异是比较结果，底层 packfile 可以使用增量压缩。
+
+### “只要文件在 Git 仓库目录里就能恢复”
+
+只有进入 Git 对象、Index、stash 或其他备份的内容才有恢复依据。未跟踪且从未保存的内容不在 Git 的恢复范围内。
+
+## 对 AI Agent 的意义
+
+Agent 完成任务后，至少应区分以下证据：
+
+| 要确认的事实 | 检查方式 |
+| --- | --- |
+| Working Tree 有哪些未暂存改动 | `git diff` |
+| Index 准备提交什么 | `git diff --cached` |
+| 当前相对 HEAD 的全部已跟踪改动 | `git diff HEAD` |
+| 是否存在未跟踪、暂存或混合状态 | `git status --short` |
+| 最近一次 commit 实际记录了什么 | `git show --stat --oneline HEAD` |
+
+实践规则：
+
+- 不把“文件已生成”写成“变更已提交”。
+- 不因为 `git diff` 为空就跳过 `git diff --cached` 和 `git status`。
+- 暂存前逐路径检查，避免直接使用范围过大的 `git add -A`。
+- 未获得提交授权时，可以验证和汇报状态，不擅自创建 commit。
+- 恢复前先区分内容是否进入过 Index、commit、stash 或其他备份。
+
+## 自测
+
+<details>
+<summary>为什么 `git status --short` 会出现 <code>MM app.txt</code>？</summary>
+
+Index 中的版本相对 HEAD 已修改，同时 Working Tree 中的版本相对 Index 也已修改。
+
+</details>
+
+<details>
+<summary>在 <code>MM app.txt</code> 状态执行 commit，会提交哪个版本？</summary>
+
+提交 Index 中的版本。实验中是 version=2。
+
+</details>
+
+<details>
+<summary>删除一个从未暂存过的未跟踪文件，reflog 能找回来吗？</summary>
+
+不能。reflog 记录引用更新，无法为从未进入 Git 的文件内容提供恢复依据。
+
+</details>
+
+## 延伸阅读
+
+- [Pro Git：Git 是什么](https://git-scm.com/book/zh/v2/%E8%B5%B7%E6%AD%A5-Git-%E6%98%AF%E4%BB%80%E4%B9%88%EF%BC%9F)
+- [Git User Manual：理解历史与快照](https://git-scm.com/docs/user-manual)
+- [`git diff` 官方文档](https://git-scm.com/docs/git-diff)
+- [`git status` 官方文档](https://git-scm.com/docs/git-status)
+- [`git commit` 官方文档](https://git-scm.com/docs/git-commit)
+- [`git restore` 官方文档](https://git-scm.com/docs/git-restore)
+- [Git 心智模型总览](git-mental-model.md)

--- a/01-getting-started/git-mental-model.md
+++ b/01-getting-started/git-mental-model.md
@@ -1,5 +1,17 @@
 # Git Mental Model
 
+[English](01-getting-started_en/git-mental-model_en.md)
+
+这篇是 Git 心智模型系列的总入口。四区域模型适合快速判断日常操作，更深入的系列会从快照、对象、引用和历史变化解释 Git 为什么这样工作。
+
+## 旗舰系列
+
+1. [快照与状态：HEAD、Index 与 Working Tree](git-mental-model-01-snapshots.md)
+
+第一章通过同一个文件的三个版本，演示 `git add` 和 `git commit` 实际记录什么，并提供[交互演示](../interactive/git-mental-model/snapshots-and-state.html)和[可运行实验](../labs/git-mental-model/01-snapshots-and-state/README.md)。
+
+## 四区域快速模型
+
 理解 Git，先理解四个区域：
 
 ```text
@@ -56,7 +68,7 @@ Git 大多数命令都在移动这几个区域之间的内容。
 | `git add` | 工作区 -> 暂存区 |
 | `git commit` | 暂存区 -> 本地仓库 |
 | `git restore` | 丢弃或恢复工作区内容 |
-| `git restore --staged` | 暂存区 -> 工作区 |
+| `git restore --staged` | 默认用 `HEAD` 恢复 Index，Working Tree 保持不变 |
 | `git push` | 本地仓库 -> 远端仓库 |
 | `git fetch` | 远端仓库 -> 本地远端引用 |
 | `git pull` | fetch + merge 或 fetch + rebase |

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Therefore, v2.0 upgrades this repository into:
 
 1.  [Why Use Git](01-getting-started/01-getting-started_en/why-git_en.md)
 2.  [Git Mental Model](01-getting-started/01-getting-started_en/git-mental-model_en.md)
-3.  [Git Basic Commands](01-getting-started/01-getting-started_en/git-basic-commands_en.md)
-4.  [Everyday Git Commands](02-daily-workflow/02-daily-workflow_en/everyday-git-commands_en.md)
+3.  [Snapshots and State: HEAD, Index, and Working Tree](01-getting-started/01-getting-started_en/git-mental-model-01-snapshots_en.md)
+4.  [Git Basic Commands](01-getting-started/01-getting-started_en/git-basic-commands_en.md)
+5.  [Everyday Git Commands](02-daily-workflow/02-daily-workflow_en/everyday-git-commands_en.md)
 
 ### Daily Development Path
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -48,8 +48,9 @@ v2.0 版本的定位是：
 
 1. [为什么使用 Git](01-getting-started/why-git.md)
 2. [Git 心智模型](01-getting-started/git-mental-model.md)
-3. [Git 基础命令](01-getting-started/git-basic-commands.md)
-4. [日常 Git 命令](02-daily-workflow/everyday-git-commands.md)
+3. [快照与状态：HEAD、Index 与 Working Tree](01-getting-started/git-mental-model-01-snapshots.md)
+4. [Git 基础命令](01-getting-started/git-basic-commands.md)
+5. [日常 Git 命令](02-daily-workflow/everyday-git-commands.md)
 
 ### 日常开发路径
 

--- a/interactive/git-mental-model/snapshots-and-state.html
+++ b/interactive/git-mental-model/snapshots-and-state.html
@@ -1,0 +1,1182 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>快照与三个状态：HEAD、索引、工作区</title>
+<meta name="description" content="交互式演示：同一个 app.txt 在 HEAD、索引、工作区中可以是三个不同版本。">
+<style>
+  :root {
+    color-scheme: light dark;
+
+    --bg: #f4f6f8;
+    --panel: #ffffff;
+    --panel-2: #eef1f5;
+    --ink: #10151b;
+    --muted: #545f6d;
+    --line: #d5dbe3;
+    --line-strong: #b6c0cb;
+    --accent: #b93d0b;
+    --accent-ink: #ffffff;
+    --accent-soft: #fbeee6;
+
+    --font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
+      "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+    --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+      "Liberation Mono", monospace;
+
+    --r-s: 4px;
+    --r-m: 8px;
+
+    --shell: 1180px;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0d1117;
+      --panel: #151b23;
+      --panel-2: #1b222b;
+      --ink: #e6edf3;
+      --muted: #9aa6b2;
+      --line: #28313b;
+      --line-strong: #3b4653;
+      --accent: #fb923c;
+      --accent-ink: #12171d;
+      --accent-soft: #251d16;
+    }
+  }
+
+  * { box-sizing: border-box; }
+
+  html { -webkit-text-size-adjust: 100%; }
+
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--font-ui);
+    font-size: 16px;
+    line-height: 1.6;
+    overflow-wrap: break-word;
+  }
+
+  code, kbd, pre, samp { font-family: var(--font-mono); }
+
+  a { color: var(--accent); text-underline-offset: 3px; }
+  a:hover { text-decoration-thickness: 2px; }
+
+  :focus-visible {
+    outline: 3px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: var(--r-s);
+  }
+
+  .skip {
+    position: absolute;
+    left: -9999px;
+    top: 8px;
+    background: var(--panel);
+    color: var(--ink);
+    border: 1px solid var(--line-strong);
+    border-radius: var(--r-s);
+    padding: 10px 14px;
+    z-index: 5;
+  }
+  .skip:focus { left: 16px; }
+
+  .shell {
+    max-width: var(--shell);
+    margin: 0 auto;
+    padding: 0 20px;
+  }
+
+  /* Masthead ------------------------------------------------------------- */
+
+  .masthead {
+    border-bottom: 1px solid var(--line);
+    background: var(--panel);
+  }
+
+  .masthead__inner {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 20px 32px;
+    padding-top: 28px;
+    padding-bottom: 26px;
+  }
+
+  .masthead__text { flex: 1 1 340px; min-width: 0; }
+
+  h1 {
+    margin: 0 0 10px;
+    font-size: clamp(1.55rem, 1.15rem + 1.7vw, 2.3rem);
+    line-height: 1.2;
+    letter-spacing: -0.01em;
+  }
+
+  h1 .h1-file {
+    font-family: var(--font-mono);
+    font-size: 0.72em;
+    color: var(--accent);
+    letter-spacing: 0;
+  }
+
+  .deck {
+    margin: 0;
+    max-width: 62ch;
+    color: var(--muted);
+    font-size: 1rem;
+  }
+
+  .lang {
+    display: flex;
+    gap: 6px;
+    padding: 4px;
+    border: 1px solid var(--line);
+    border-radius: var(--r-m);
+    background: var(--panel-2);
+    flex: 0 0 auto;
+  }
+
+  .lang button {
+    min-height: 44px;
+    min-width: 78px;
+    padding: 0 14px;
+    border: 1px solid transparent;
+    border-radius: var(--r-s);
+    background: transparent;
+    color: var(--muted);
+    font: inherit;
+    font-size: 0.92rem;
+    cursor: pointer;
+    transition: background-color 120ms ease, color 120ms ease;
+  }
+
+  .lang button:hover { color: var(--ink); }
+
+  .lang button[aria-pressed="true"] {
+    background: var(--panel);
+    border-color: var(--line-strong);
+    color: var(--ink);
+    font-weight: 600;
+  }
+
+  /* Layout --------------------------------------------------------------- */
+
+  .layout {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 24px;
+    padding-top: 26px;
+    padding-bottom: 40px;
+    align-items: start;
+  }
+
+  @media (min-width: 1000px) {
+    .layout {
+      grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+      gap: 28px;
+    }
+    .rail { position: sticky; top: 20px; }
+  }
+
+  .panel {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: var(--r-m);
+    min-width: 0;
+  }
+
+  .panel__head {
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .panel__title {
+    margin: 0;
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+
+  .panel__hint {
+    margin: 4px 0 0;
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+
+  /* Rail ----------------------------------------------------------------- */
+
+  .steps {
+    list-style: none;
+    margin: 0;
+    padding: 8px;
+    display: grid;
+    gap: 6px;
+  }
+
+  .step {
+    display: grid;
+    grid-template-columns: 3px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0 12px;
+    width: 100%;
+    min-height: 56px;
+    padding: 10px 12px;
+    border: 1px solid var(--line);
+    border-radius: var(--r-s);
+    background: var(--panel);
+    color: var(--ink);
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: border-color 140ms ease, background-color 140ms ease,
+      transform 140ms ease;
+  }
+
+  .step::before {
+    content: "";
+    grid-column: 1;
+    grid-row: 1 / span 2;
+    align-self: stretch;
+    background: var(--line-strong);
+    border-radius: 2px;
+    transition: background-color 140ms ease;
+  }
+
+  .step:hover { border-color: var(--line-strong); background: var(--panel-2); }
+
+  .step[aria-current="step"] {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+  }
+
+  .step[aria-current="step"]::before { background: var(--accent); }
+
+  .step__label {
+    grid-column: 2;
+    grid-row: 1;
+    font-weight: 600;
+    font-size: 0.95rem;
+  }
+
+  .step__changes {
+    grid-column: 2;
+    grid-row: 2;
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
+
+  .step[aria-current="step"] .step__changes { color: var(--ink); }
+
+  .step__versions {
+    grid-column: 3;
+    grid-row: 1 / span 2;
+    font-family: var(--font-mono);
+    font-size: 0.86rem;
+    color: var(--muted);
+    white-space: nowrap;
+  }
+
+  .step[aria-current="step"] .step__versions { color: var(--accent); font-weight: 700; }
+
+  .rail__legend {
+    margin: 0;
+    padding: 0 16px 14px;
+    font-size: 0.78rem;
+    color: var(--muted);
+  }
+
+  .rail__legend code { font-size: 0.95em; }
+
+  /* Board ---------------------------------------------------------------- */
+
+  .board { display: grid; gap: 20px; min-width: 0; }
+
+  .toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 16px;
+  }
+
+  .progress {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    color: var(--muted);
+  }
+
+  .controls { display: flex; flex-wrap: wrap; gap: 8px; }
+
+  .btn {
+    min-height: 44px;
+    min-width: 44px;
+    padding: 0 16px;
+    border: 1px solid var(--line-strong);
+    border-radius: var(--r-s);
+    background: var(--panel);
+    color: var(--ink);
+    font: inherit;
+    font-size: 0.92rem;
+    cursor: pointer;
+    transition: background-color 120ms ease, border-color 120ms ease;
+  }
+
+  .btn:hover { background: var(--panel-2); }
+
+  .btn[disabled] {
+    cursor: not-allowed;
+    color: var(--muted);
+    opacity: 0.55;
+    background: var(--panel);
+  }
+
+  .btn--primary {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--accent-ink);
+    font-weight: 600;
+  }
+
+  .btn--primary:hover { background: var(--accent); filter: brightness(1.08); }
+  .btn--primary:focus-visible { outline-color: var(--ink); }
+  .btn--primary[disabled] { background: var(--panel); color: var(--muted); border-color: var(--line-strong); filter: none; }
+
+  /* Command -------------------------------------------------------------- */
+
+  .command {
+    margin: 0;
+    padding: 16px;
+    font-size: 0.98rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .command__prompt { color: var(--accent); font-weight: 700; }
+  .command--idle { color: var(--muted); font-style: normal; }
+
+  /* Columns -------------------------------------------------------------- */
+
+  .columns {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  @media (min-width: 720px) {
+    .columns { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  }
+
+  .column {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    padding: 14px;
+    border: 1px solid var(--line);
+    border-radius: var(--r-m);
+    background: var(--panel);
+    transition: border-color 200ms ease, background-color 200ms ease;
+  }
+
+  .column.is-changed {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+  }
+
+  .column__name {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.95rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+  }
+
+  .column__role {
+    margin: 4px 0 12px;
+    font-size: 0.82rem;
+    color: var(--muted);
+    min-height: 2.6em;
+  }
+
+  .column__file {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+    padding-bottom: 8px;
+    border-bottom: 1px dashed var(--line-strong);
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    color: var(--muted);
+  }
+
+  .column__value {
+    margin: 0;
+    padding: 14px 0 4px;
+    font-family: var(--font-mono);
+    font-size: clamp(1.05rem, 0.95rem + 0.6vw, 1.35rem);
+    font-weight: 700;
+    letter-spacing: 0.01em;
+  }
+
+  .column__flag {
+    margin: 6px 0 0;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--accent);
+  }
+
+  .column__flag[hidden] { display: none; }
+
+  @keyframes value-in {
+    from { opacity: 0; transform: translateY(7px); }
+    to { opacity: 1; transform: none; }
+  }
+
+  .column.is-animating .column__value { animation: value-in 320ms cubic-bezier(0.2, 0.7, 0.3, 1); }
+  .column.is-animating .column__flag { animation: value-in 380ms cubic-bezier(0.2, 0.7, 0.3, 1); }
+
+  /* Status --------------------------------------------------------------- */
+
+  .status__body { padding: 16px; display: grid; gap: 14px; }
+
+  .status__out {
+    margin: 0;
+    padding: 12px 14px;
+    background: var(--panel-2);
+    border: 1px solid var(--line);
+    border-radius: var(--r-s);
+    font-size: 0.98rem;
+    white-space: pre;
+    overflow-x: auto;
+  }
+
+  .status__out[hidden] { display: none; }
+
+  .status__empty {
+    margin: 0;
+    padding: 12px 14px;
+    background: var(--panel-2);
+    border: 1px dashed var(--line-strong);
+    border-radius: var(--r-s);
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.92rem;
+  }
+
+  .status__empty[hidden] { display: none; }
+
+  .status__note { margin: 0; font-size: 0.92rem; }
+
+  .codes {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    margin: 0;
+  }
+
+  @media (max-width: 520px) {
+    .codes { grid-template-columns: minmax(0, 1fr); }
+  }
+
+  .code-cell {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border: 1px solid var(--line);
+    border-radius: var(--r-s);
+    background: var(--panel-2);
+    min-width: 0;
+  }
+
+  .code-cell__char {
+    order: -1;
+    margin: 0;
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border: 1px solid var(--line-strong);
+    border-radius: var(--r-s);
+    background: var(--panel);
+    font-family: var(--font-mono);
+    font-size: 1.05rem;
+    font-weight: 700;
+  }
+
+  .code-cell.is-empty .code-cell__char {
+    border-style: dashed;
+    color: var(--muted);
+  }
+
+  .code-cell.is-set .code-cell__char {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  .code-cell__label { font-size: 0.82rem; color: var(--muted); min-width: 0; }
+
+  .legend {
+    margin: 0;
+    display: grid;
+    gap: 8px;
+    font-size: 0.86rem;
+  }
+
+  .legend div { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 10px; align-items: baseline; }
+
+  .legend dt {
+    font-family: var(--font-mono);
+    font-weight: 700;
+    white-space: nowrap;
+  }
+
+  .legend dd { margin: 0; color: var(--muted); }
+
+  /* Explanation ---------------------------------------------------------- */
+
+  .readout__body { padding: 16px; }
+
+  .readout__text { margin: 0; font-size: 1rem; max-width: 72ch; }
+
+  .readout__text code {
+    padding: 1px 5px;
+    border: 1px solid var(--line);
+    border-radius: var(--r-s);
+    background: var(--panel-2);
+    font-size: 0.92em;
+  }
+
+  .keyhint {
+    margin: 0;
+    padding: 0 16px 14px;
+    font-size: 0.82rem;
+    color: var(--muted);
+  }
+
+  kbd {
+    padding: 1px 6px;
+    border: 1px solid var(--line-strong);
+    border-bottom-width: 2px;
+    border-radius: var(--r-s);
+    background: var(--panel-2);
+    font-size: 0.85em;
+  }
+
+  /* noscript ------------------------------------------------------------- */
+
+  .fallback {
+    margin: 20px 0 0;
+    padding: 16px;
+    border: 1px solid var(--accent);
+    border-radius: var(--r-m);
+    background: var(--accent-soft);
+  }
+
+  .fallback p { margin: 0 0 10px; }
+  .fallback p:last-child { margin-bottom: 0; }
+
+  .fallback__scroll {
+    overflow-x: auto;
+    margin-bottom: 10px;
+  }
+
+  .fallback table {
+    width: 100%;
+    min-width: 520px;
+    border-collapse: collapse;
+    font-size: 0.86rem;
+  }
+
+  .fallback th, .fallback td {
+    padding: 6px 8px;
+    border: 1px solid var(--line-strong);
+    text-align: left;
+    vertical-align: top;
+  }
+
+  .fallback td { font-family: var(--font-mono); }
+
+  /* Footer --------------------------------------------------------------- */
+
+  .colophon {
+    border-top: 1px solid var(--line);
+    background: var(--panel);
+  }
+
+  .colophon__inner {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 24px;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20px 0;
+    font-size: 0.9rem;
+    color: var(--muted);
+  }
+
+  .colophon__note { margin: 0; max-width: 46ch; }
+
+  .back-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    font-weight: 600;
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.001ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.001ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
+</style>
+</head>
+<body>
+
+<a class="skip" href="#board" data-en="Skip to the interactive demo">跳到交互演示</a>
+
+<header class="masthead">
+  <div class="shell masthead__inner">
+    <div class="masthead__text">
+      <h1>
+        <span data-en="Three states of one file:">同一个文件的三个状态：</span>
+        <span class="h1-file">HEAD / index / working tree</span>
+      </h1>
+      <p class="deck" data-en="One file named app.txt can hold three different versions at the same time. Step through five states and watch which state each command actually changes.">一个名为 app.txt 的文件，可以同时存在三个不同版本。走完下面五个状态，看清每条命令真正改动了哪一层。</p>
+    </div>
+    <div class="lang" role="group" aria-label="Language / 语言">
+      <button type="button" id="lang-zh" aria-pressed="true" lang="zh-CN">中文</button>
+      <button type="button" id="lang-en" aria-pressed="false" lang="en">English</button>
+    </div>
+  </div>
+</header>
+
+<div class="shell">
+  <noscript>
+    <div class="fallback">
+      <p data-en="JavaScript is disabled, so this page shows the initial state only: HEAD, the index, and the working tree all hold version=1. The full five-state walkthrough is listed below."><strong>提示：</strong>浏览器停用了 JavaScript，页面只显示初始状态：HEAD、索引、工作区都是 version=1。完整的五个状态见下表。</p>
+      <div class="fallback__scroll">
+      <table>
+        <caption class="visually-hidden">五个状态对照表 / Five states</caption>
+        <thead>
+          <tr>
+            <th scope="col">命令 / Command</th>
+            <th scope="col">HEAD</th>
+            <th scope="col">Index</th>
+            <th scope="col">Working Tree</th>
+            <th scope="col">git status --short</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td>(初始状态 / initial)</td><td>version=1</td><td>version=1</td><td>version=1</td><td>(无输出 / no output)</td></tr>
+          <tr><td>printf 'version=2\n' &gt; app.txt</td><td>version=1</td><td>version=1</td><td>version=2</td><td>" M app.txt"</td></tr>
+          <tr><td>git add app.txt</td><td>version=1</td><td>version=2</td><td>version=2</td><td>"M  app.txt"</td></tr>
+          <tr><td>printf 'version=3\n' &gt; app.txt</td><td>version=1</td><td>version=2</td><td>version=3</td><td>"MM app.txt"</td></tr>
+          <tr><td>git commit -m 'record version 2'</td><td>version=2</td><td>version=2</td><td>version=3</td><td>" M app.txt"</td></tr>
+        </tbody>
+      </table>
+      </div>
+      <p data-en="The last row is the point of this page: the commit records the snapshot held in the index, and the newer working-tree edit stays uncommitted.">最后一行是这个页面的重点：提交记录的是索引里的快照，后来在工作区里做的修改没有进入这次提交。</p>
+    </div>
+  </noscript>
+
+  <div class="layout">
+
+    <nav class="panel rail" aria-label="状态步骤 / State steps">
+      <div class="panel__head">
+        <h2 class="panel__title" data-en="States">状态序列</h2>
+        <p class="panel__hint" data-en="Right column: version in HEAD / index / working tree.">右侧数字是 HEAD / 索引 / 工作区 中的版本号。</p>
+      </div>
+      <ol class="steps" id="steps">
+        <li>
+          <button type="button" class="step" data-step="0" aria-current="step">
+            <span class="step__label" data-en="Initial state">初始状态</span>
+            <span class="step__changes" data-en="All three states match">三个状态一致</span>
+            <span class="step__versions" aria-hidden="true">1 / 1 / 1</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="step" data-step="1">
+            <span class="step__label" data-en="Edit the file">修改文件</span>
+            <span class="step__changes" data-en="Changes the working tree">改动工作区</span>
+            <span class="step__versions" aria-hidden="true">1 / 1 / 2</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="step" data-step="2">
+            <span class="step__label" data-en="Stage the change">暂存改动</span>
+            <span class="step__changes" data-en="Changes the index">改动索引</span>
+            <span class="step__versions" aria-hidden="true">1 / 2 / 2</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="step" data-step="3">
+            <span class="step__label" data-en="Edit the file again">再次修改文件</span>
+            <span class="step__changes" data-en="Changes the working tree">改动工作区</span>
+            <span class="step__versions" aria-hidden="true">1 / 2 / 3</span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="step" data-step="4">
+            <span class="step__label" data-en="Commit">提交</span>
+            <span class="step__changes" data-en="Changes HEAD">改动 HEAD</span>
+            <span class="step__versions" aria-hidden="true">2 / 2 / 3</span>
+          </button>
+        </li>
+      </ol>
+      <p class="rail__legend" data-en="The version number is the content of app.txt in that state, for example version=2.">版本号表示该状态里 app.txt 的内容，例如 version=2。</p>
+    </nav>
+
+    <main class="board" id="board" tabindex="-1">
+
+      <section class="panel" aria-labelledby="toolbar-title">
+        <h2 class="visually-hidden" id="toolbar-title">导航 / Navigation</h2>
+        <div class="toolbar">
+          <p class="progress" id="progress">状态 1 / 5</p>
+          <div class="controls">
+            <button type="button" class="btn" id="btn-prev" disabled data-en="Previous">上一步</button>
+            <button type="button" class="btn btn--primary" id="btn-next" data-en="Next">下一步</button>
+            <button type="button" class="btn" id="btn-reset" data-en="Reset">回到起点</button>
+          </div>
+        </div>
+        <p class="keyhint">
+          <span data-en="Keyboard:">键盘：</span>
+          <kbd>&larr;</kbd> <kbd>&rarr;</kbd>
+          <span data-en="move between states,">切换状态，</span>
+          <kbd>Home</kbd>
+          <span data-en="jumps to the initial state,">回到初始状态，</span>
+          <kbd>End</kbd>
+          <span data-en="jumps to the commit state.">跳到提交状态。</span>
+        </p>
+      </section>
+
+      <section class="panel" aria-labelledby="command-title">
+        <div class="panel__head">
+          <h2 class="panel__title" id="command-title" data-en="Command">执行的命令</h2>
+        </div>
+        <p class="command" id="command"><span class="command--idle">尚未执行命令，这是仓库刚提交完的起点。</span></p>
+      </section>
+
+      <section aria-labelledby="columns-title">
+        <h2 class="visually-hidden" id="columns-title">三个状态 / Three states</h2>
+        <div class="columns">
+          <article class="column" id="col-head">
+            <h3 class="column__name">HEAD</h3>
+            <p class="column__role" data-en="Snapshot recorded by the latest commit">最新一次提交记录下来的快照</p>
+            <p class="column__file"><span>app.txt</span><span data-en="content" class="column__filenote">内容</span></p>
+            <p class="column__value">version=1</p>
+            <p class="column__flag" hidden data-en="Updated by this command">这条命令更新了它</p>
+          </article>
+          <article class="column" id="col-index">
+            <h3 class="column__name">Index</h3>
+            <p class="column__role" data-en="What the next commit will record">下一次提交会记录的内容</p>
+            <p class="column__file"><span>app.txt</span><span data-en="content" class="column__filenote">内容</span></p>
+            <p class="column__value">version=1</p>
+            <p class="column__flag" hidden data-en="Updated by this command">这条命令更新了它</p>
+          </article>
+          <article class="column" id="col-work">
+            <h3 class="column__name">Working Tree</h3>
+            <p class="column__role" data-en="The file you are editing on disk">你正在磁盘上编辑的文件</p>
+            <p class="column__file"><span>app.txt</span><span data-en="content" class="column__filenote">内容</span></p>
+            <p class="column__value">version=1</p>
+            <p class="column__flag" hidden data-en="Updated by this command">这条命令更新了它</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="status-title">
+        <div class="panel__head">
+          <h2 class="panel__title" id="status-title"><code>git status --short</code></h2>
+        </div>
+        <div class="status__body">
+          <pre class="status__out" id="status-out" hidden><code></code></pre>
+          <p class="status__empty" id="status-empty" data-en="(no output)">（没有输出）</p>
+          <dl class="codes">
+            <div class="code-cell is-empty" id="code-1">
+              <dt class="code-cell__label" data-en="Position 1: index vs HEAD">第一位：索引与 HEAD 的差异</dt>
+              <dd class="code-cell__char"><span id="code-1-char"></span><span class="visually-hidden" id="code-1-sr">空格</span></dd>
+            </div>
+            <div class="code-cell is-empty" id="code-2">
+              <dt class="code-cell__label" data-en="Position 2: working tree vs index">第二位：工作区与索引的差异</dt>
+              <dd class="code-cell__char"><span id="code-2-char"></span><span class="visually-hidden" id="code-2-sr">空格</span></dd>
+            </div>
+          </dl>
+          <p class="status__note" id="status-note">三个状态没有差异，所以这条命令什么都不输出。</p>
+          <dl class="legend">
+            <div>
+              <dt>M<span class="visually-hidden" data-en=" in position 1">，第一位</span></dt>
+              <dd data-en="in position 1: the index differs from HEAD, the change is staged.">出现在第一位：索引与 HEAD 不同，改动已经暂存。</dd>
+            </div>
+            <div>
+              <dt>M<span class="visually-hidden" data-en=" in position 2">，第二位</span></dt>
+              <dd data-en="in position 2: the working tree differs from the index, the change is not staged.">出现在第二位：工作区与索引不同，改动还没有暂存。</dd>
+            </div>
+            <div>
+              <dt><span aria-hidden="true">&nbsp;</span><span class="visually-hidden" data-en="space">空格</span></dt>
+              <dd data-en="A space in either position means there is no difference on that side.">空格表示这一位对应的两层内容相同。</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="readout-title">
+        <div class="panel__head">
+          <h2 class="panel__title" id="readout-title" data-en="What changed">这一步发生了什么</h2>
+        </div>
+        <div class="readout__body">
+          <p class="readout__text" id="readout" aria-live="polite">仓库刚刚提交过，HEAD、索引、工作区保存的都是 version=1。三层内容一致时，git status --short 没有输出。</p>
+        </div>
+      </section>
+
+    </main>
+  </div>
+</div>
+
+<footer class="colophon">
+  <div class="shell colophon__inner">
+    <a class="back-link" id="back-link" href="../../01-getting-started/git-mental-model-01-snapshots.md" data-en="Back to the article: snapshots and state">返回文章：快照与状态</a>
+    <p class="colophon__note" data-en="The states here follow real Git behavior for one tracked file.">页面里的状态与真实 Git 对单个已跟踪文件的行为一致。</p>
+  </div>
+</footer>
+
+<script>
+(function () {
+  "use strict";
+
+  var STEPS = [
+    {
+      command: null,
+      idle: {
+        zh: "尚未执行命令，这是仓库刚提交完的起点。",
+        en: "No command run yet. This is the starting point right after a commit."
+      },
+      head: "version=1",
+      index: "version=1",
+      work: "version=1",
+      changed: [],
+      status: "",
+      codes: ["", ""],
+      note: {
+        zh: "三个状态没有差异，所以这条命令什么都不输出。",
+        en: "The three states hold the same content, so the command prints nothing."
+      },
+      readout: {
+        zh: "仓库刚刚提交过，`HEAD`、索引、工作区保存的都是 `version=1`。三层内容一致时，`git status --short` 没有输出。",
+        en: "The repository was just committed, so `HEAD`, the index, and the working tree all hold `version=1`. When the three layers match, `git status --short` prints nothing."
+      }
+    },
+    {
+      command: "printf 'version=2\\n' > app.txt",
+      head: "version=1",
+      index: "version=1",
+      work: "version=2",
+      changed: ["work"],
+      status: " M app.txt",
+      codes: ["", "M"],
+      note: {
+        zh: "第一位是空格，第二位是 M：改动还没有暂存。",
+        en: "Position 1 is a space and position 2 is M: the change is not staged yet."
+      },
+      readout: {
+        zh: "改写文件只动了工作区。索引和 `HEAD` 仍然是 `version=1`，所以短状态的第二位出现 `M`，表示存在未暂存的修改。",
+        en: "Rewriting the file only touched the working tree. The index and `HEAD` still hold `version=1`, so position 2 of the short status shows `M`, meaning there is an unstaged change."
+      }
+    },
+    {
+      command: "git add app.txt",
+      head: "version=1",
+      index: "version=2",
+      work: "version=2",
+      changed: ["index"],
+      status: "M  app.txt",
+      codes: ["M", ""],
+      note: {
+        zh: "第一位是 M，第二位是空格：改动已经进入索引。",
+        en: "Position 1 is M and position 2 is a space: the change is now in the index."
+      },
+      readout: {
+        zh: "`git add` 把工作区当前的内容复制进索引，索引变成 `version=2`。第一位变成 `M`，表示索引与 `HEAD` 有差异；第二位回到空格，表示工作区与索引已经一致。",
+        en: "`git add` copies the current working-tree content into the index, so the index becomes `version=2`. Position 1 turns into `M` because the index now differs from `HEAD`, and position 2 returns to a space because the working tree matches the index."
+      }
+    },
+    {
+      command: "printf 'version=3\\n' > app.txt",
+      head: "version=1",
+      index: "version=2",
+      work: "version=3",
+      changed: ["work"],
+      status: "MM app.txt",
+      codes: ["M", "M"],
+      note: {
+        zh: "两位都是 M：索引和工作区各自都有差异。",
+        en: "Both positions are M: the index and the working tree each carry a difference."
+      },
+      readout: {
+        zh: "第三次改写同样只影响工作区，索引仍然停在 `version=2`。两位都是 `M`：索引相对 `HEAD` 有差异，工作区相对索引也有差异。这时同一个文件在三层里是三个版本。",
+        en: "The third edit again touches only the working tree, while the index stays at `version=2`. Both positions show `M`: the index differs from `HEAD`, and the working tree differs from the index. One file now holds three versions across the three layers."
+      }
+    },
+    {
+      command: "git commit -m 'record version 2'",
+      head: "version=2",
+      index: "version=2",
+      work: "version=3",
+      changed: ["head"],
+      status: " M app.txt",
+      codes: ["", "M"],
+      note: {
+        zh: "第一位回到空格，第二位是 M：只剩工作区里的 version=3 还没有暂存。",
+        en: "Position 1 returns to a space and position 2 is M: only the version=3 edit in the working tree is still unstaged."
+      },
+      readout: {
+        zh: "`git commit` 记录的是索引里的快照，所以这次提交的内容是 `version=2`，`HEAD` 前进到 `version=2`。工作区里的 `version=3` 没有进入这次提交，它依然是未暂存的修改，要再执行一次 `git add` 才会被下一个提交记录。",
+        en: "`git commit` records the snapshot held in the index, so the new commit contains `version=2` and `HEAD` moves to `version=2`. The `version=3` edit in the working tree stayed out of this commit and remains an unstaged change until you run `git add` again."
+      }
+    }
+  ];
+
+  var SPACE_WORD = { zh: "空格", en: "space" };
+
+  var els = {
+    steps: Array.prototype.slice.call(document.querySelectorAll(".step")),
+    progress: document.getElementById("progress"),
+    prev: document.getElementById("btn-prev"),
+    next: document.getElementById("btn-next"),
+    reset: document.getElementById("btn-reset"),
+    command: document.getElementById("command"),
+    statusOut: document.getElementById("status-out"),
+    statusEmpty: document.getElementById("status-empty"),
+    statusNote: document.getElementById("status-note"),
+    readout: document.getElementById("readout"),
+    backLink: document.getElementById("back-link"),
+    langZh: document.getElementById("lang-zh"),
+    langEn: document.getElementById("lang-en"),
+    codes: [
+      {
+        box: document.getElementById("code-1"),
+        char: document.getElementById("code-1-char"),
+        sr: document.getElementById("code-1-sr")
+      },
+      {
+        box: document.getElementById("code-2"),
+        char: document.getElementById("code-2-char"),
+        sr: document.getElementById("code-2-sr")
+      }
+    ],
+    columns: {
+      head: document.getElementById("col-head"),
+      index: document.getElementById("col-index"),
+      work: document.getElementById("col-work")
+    }
+  };
+
+  var TITLES = {
+    zh: "快照与三个状态：HEAD、索引、工作区",
+    en: "Snapshots and three states: HEAD, index, working tree"
+  };
+
+  var lang = "zh";
+  var current = 0;
+
+  function pick(pair) {
+    return lang === "en" ? pair.en : pair.zh;
+  }
+
+  /* Renders text where `backticks` become inline code elements. */
+  function renderRich(target, text) {
+    target.textContent = "";
+    var parts = text.split("`");
+    for (var i = 0; i < parts.length; i += 1) {
+      if (!parts[i]) { continue; }
+      if (i % 2 === 1) {
+        var code = document.createElement("code");
+        code.textContent = parts[i];
+        target.appendChild(code);
+      } else {
+        target.appendChild(document.createTextNode(parts[i]));
+      }
+    }
+  }
+
+  function renderCommand(step) {
+    els.command.textContent = "";
+    if (!step.command) {
+      var idle = document.createElement("span");
+      idle.className = "command--idle";
+      idle.textContent = pick(step.idle);
+      els.command.appendChild(idle);
+      return;
+    }
+    var prompt = document.createElement("span");
+    prompt.className = "command__prompt";
+    prompt.textContent = "$ ";
+    els.command.appendChild(prompt);
+    els.command.appendChild(document.createTextNode(step.command));
+  }
+
+  function renderStatus(step) {
+    if (step.status) {
+      els.statusOut.hidden = false;
+      els.statusOut.firstChild.textContent = step.status;
+      els.statusEmpty.hidden = true;
+    } else {
+      els.statusOut.hidden = true;
+      els.statusOut.firstChild.textContent = "";
+      els.statusEmpty.hidden = false;
+    }
+
+    for (var i = 0; i < els.codes.length; i += 1) {
+      var value = step.codes[i];
+      var cell = els.codes[i];
+      cell.char.textContent = value;
+      cell.sr.textContent = value ? value : pick(SPACE_WORD);
+      cell.box.classList.toggle("is-set", Boolean(value));
+      cell.box.classList.toggle("is-empty", !value);
+    }
+
+    els.statusNote.textContent = pick(step.note);
+  }
+
+  function renderColumns(step, animate) {
+    var keys = ["head", "index", "work"];
+    for (var i = 0; i < keys.length; i += 1) {
+      var key = keys[i];
+      var col = els.columns[key];
+      var value = col.querySelector(".column__value");
+      var flag = col.querySelector(".column__flag");
+      var changed = step.changed.indexOf(key) !== -1;
+
+      value.textContent = step[key];
+      flag.hidden = !changed;
+      col.classList.toggle("is-changed", changed);
+      col.classList.remove("is-animating");
+
+      if (changed && animate) {
+        /* Force a reflow so the animation restarts on every transition. */
+        void col.offsetWidth;
+        col.classList.add("is-animating");
+      }
+    }
+  }
+
+  function renderNav() {
+    for (var i = 0; i < els.steps.length; i += 1) {
+      if (i === current) {
+        els.steps[i].setAttribute("aria-current", "step");
+      } else {
+        els.steps[i].removeAttribute("aria-current");
+      }
+    }
+    els.prev.disabled = current === 0;
+    els.next.disabled = current === STEPS.length - 1;
+    els.progress.textContent = lang === "en"
+      ? "State " + (current + 1) + " of " + STEPS.length
+      : "状态 " + (current + 1) + " / " + STEPS.length;
+  }
+
+  /* Keeps focus usable when the focused control becomes disabled or stale. */
+  function restoreFocus(active) {
+    if (!active || active === document.body) { return; }
+    if (active === els.next && els.next.disabled) { els.prev.focus(); return; }
+    if (active === els.prev && els.prev.disabled) { els.next.focus(); return; }
+    if (active.classList && active.classList.contains("step")) {
+      els.steps[current].focus();
+    }
+  }
+
+  function render(animate) {
+    var active = document.activeElement;
+    var step = STEPS[current];
+    renderCommand(step);
+    renderColumns(step, animate);
+    renderStatus(step);
+    renderRich(els.readout, pick(step.readout));
+    renderNav();
+    restoreFocus(active);
+  }
+
+  function goTo(index) {
+    var next = Math.min(Math.max(index, 0), STEPS.length - 1);
+    if (next === current) { return; }
+    current = next;
+    render(true);
+  }
+
+  function setLang(nextLang) {
+    lang = nextLang;
+    document.documentElement.lang = lang === "en" ? "en" : "zh-CN";
+    document.title = lang === "en" ? TITLES.en : TITLES.zh;
+    els.langZh.setAttribute("aria-pressed", String(lang === "zh"));
+    els.langEn.setAttribute("aria-pressed", String(lang === "en"));
+
+    var swappable = document.querySelectorAll("[data-en]");
+    for (var i = 0; i < swappable.length; i += 1) {
+      var el = swappable[i];
+      if (!el.dataset.zh) { el.dataset.zh = el.textContent; }
+      el.textContent = lang === "en" ? el.dataset.en : el.dataset.zh;
+    }
+
+    render(false);
+  }
+
+  for (var i = 0; i < els.steps.length; i += 1) {
+    (function (button) {
+      button.addEventListener("click", function () {
+        goTo(Number(button.dataset.step));
+      });
+    })(els.steps[i]);
+  }
+
+  els.prev.addEventListener("click", function () { goTo(current - 1); });
+  els.next.addEventListener("click", function () { goTo(current + 1); });
+  els.reset.addEventListener("click", function () { goTo(0); });
+  els.langZh.addEventListener("click", function () { setLang("zh"); });
+  els.langEn.addEventListener("click", function () { setLang("en"); });
+
+  document.addEventListener("keydown", function (event) {
+    if (event.altKey || event.ctrlKey || event.metaKey) { return; }
+    var handled = true;
+    switch (event.key) {
+      case "ArrowLeft": goTo(current - 1); break;
+      case "ArrowRight": goTo(current + 1); break;
+      case "Home": goTo(0); break;
+      case "End": goTo(STEPS.length - 1); break;
+      default: handled = false;
+    }
+    if (handled) { event.preventDefault(); }
+  });
+
+  /* The noscript fallback keeps its own copy, so only live UI is rendered. */
+  render(false);
+})();
+</script>
+
+</body>
+</html>

--- a/labs/git-mental-model/01-snapshots-and-state/README.md
+++ b/labs/git-mental-model/01-snapshots-and-state/README.md
@@ -1,0 +1,51 @@
+# Snapshots and State Lab / 快照与状态实验
+
+[中文文章](../../../01-getting-started/git-mental-model-01-snapshots.md) | [English article](../../../01-getting-started/01-getting-started_en/git-mental-model-01-snapshots_en.md) | [Interactive demo](../../../interactive/git-mental-model/snapshots-and-state.html)
+
+## 中文
+
+这个实验创建一个临时 Git 仓库，并让 `app.txt` 同时处于以下状态：
+
+```text
+HEAD=version=1    Index=version=2    Working Tree=version=3
+```
+
+运行：
+
+```bash
+lab_path=$(bash setup.sh)
+bash verify.sh "$lab_path"
+bash cleanup.sh "$lab_path"
+```
+
+`setup.sh` 的标准输出只有临时仓库路径，便于在脚本中安全引用。`verify.sh` 会检查三个版本和 `MM app.txt` 状态。`cleanup.sh` 只接受带有本实验标记的仓库路径。
+
+也可以一次运行完整自测：
+
+```bash
+bash test.sh
+```
+
+## English
+
+This lab creates a temporary Git repository in which `app.txt` has three simultaneous states:
+
+```text
+HEAD=version=1    Index=version=2    Working Tree=version=3
+```
+
+Run:
+
+```bash
+lab_path=$(bash setup.sh)
+bash verify.sh "$lab_path"
+bash cleanup.sh "$lab_path"
+```
+
+The only standard output from `setup.sh` is the temporary repository path, so scripts can capture it safely. `verify.sh` checks all three versions and the `MM app.txt` state. `cleanup.sh` accepts only a repository marked as belonging to this lab.
+
+Run the full self-test with:
+
+```bash
+bash test.sh
+```

--- a/labs/git-mental-model/01-snapshots-and-state/cleanup.sh
+++ b/labs/git-mental-model/01-snapshots-and-state/cleanup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 1 )); then
+  echo "usage: $0 <lab-repository>" >&2
+  exit 2
+fi
+
+requested=$1
+if [[ ! -d "$requested" ]]; then
+  echo "lab repository does not exist: $requested" >&2
+  exit 1
+fi
+
+lab_dir=$(cd "$requested" && pwd -P)
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+project_root=$(cd "$script_dir/../../.." && pwd -P)
+
+if [[ "$lab_dir" == "/" || "$lab_dir" == "$HOME" || "$lab_dir" == "$project_root" ]]; then
+  echo "refusing to remove protected directory: $lab_dir" >&2
+  exit 1
+fi
+
+if [[ ! -f "$lab_dir/.git/my-git-lab" ]] || [[ "$(<"$lab_dir/.git/my-git-lab")" != "snapshots-and-state" ]]; then
+  echo "refusing to remove an unmarked directory: $lab_dir" >&2
+  exit 1
+fi
+
+rm -rf -- "$lab_dir"
+printf 'removed lab repository: %s\n' "$lab_dir"

--- a/labs/git-mental-model/01-snapshots-and-state/expected.txt
+++ b/labs/git-mental-model/01-snapshots-and-state/expected.txt
@@ -1,0 +1,9 @@
+Snapshots and State / 快照与状态
+
+HEAD:         version=1
+Index:        version=2
+Working Tree: version=3
+Status:       MM app.txt
+
+After `git commit`, Git records version=2 from the index. The version=3
+working-tree edit remains uncommitted.

--- a/labs/git-mental-model/01-snapshots-and-state/setup.sh
+++ b/labs/git-mental-model/01-snapshots-and-state/setup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# > 1 )); then
+  echo "usage: $0 [target-directory]" >&2
+  exit 2
+fi
+
+if (( $# == 1 )); then
+  lab_dir=$1
+  if [[ -e "$lab_dir" && ! -d "$lab_dir" ]]; then
+    echo "target exists and is not a directory: $lab_dir" >&2
+    exit 1
+  fi
+  mkdir -p "$lab_dir"
+  if [[ -n "$(find "$lab_dir" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+    echo "target directory must be empty: $lab_dir" >&2
+    exit 1
+  fi
+else
+  lab_dir=$(mktemp -d "${TMPDIR:-/tmp}/my-git-snapshots.XXXXXX")
+fi
+
+lab_dir=$(cd "$lab_dir" && pwd -P)
+
+git -c init.defaultBranch=main init -q "$lab_dir"
+git -C "$lab_dir" config user.name "My Git Lab"
+git -C "$lab_dir" config user.email "lab@example.com"
+printf 'snapshots-and-state\n' > "$lab_dir/.git/my-git-lab"
+
+printf 'version=1\n' > "$lab_dir/app.txt"
+git -C "$lab_dir" add app.txt
+GIT_AUTHOR_DATE='2026-01-01T00:00:00Z' \
+GIT_COMMITTER_DATE='2026-01-01T00:00:00Z' \
+  git -C "$lab_dir" commit -q -m "record version 1"
+
+printf 'version=2\n' > "$lab_dir/app.txt"
+git -C "$lab_dir" add app.txt
+printf 'version=3\n' > "$lab_dir/app.txt"
+
+printf '%s\n' "$lab_dir"

--- a/labs/git-mental-model/01-snapshots-and-state/test.sh
+++ b/labs/git-mental-model/01-snapshots-and-state/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+lab_dir=$(bash "$script_dir/setup.sh")
+
+cleanup() {
+  if [[ -d "$lab_dir" ]]; then
+    bash "$script_dir/cleanup.sh" "$lab_dir" >/dev/null
+  fi
+}
+trap cleanup EXIT
+
+bash "$script_dir/verify.sh" "$lab_dir"

--- a/labs/git-mental-model/01-snapshots-and-state/verify.sh
+++ b/labs/git-mental-model/01-snapshots-and-state/verify.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 1 )); then
+  echo "usage: $0 <lab-repository>" >&2
+  exit 2
+fi
+
+lab_dir=$1
+if [[ ! -f "$lab_dir/.git/my-git-lab" ]] || [[ "$(<"$lab_dir/.git/my-git-lab")" != "snapshots-and-state" ]]; then
+  echo "not a snapshots-and-state lab repository: $lab_dir" >&2
+  exit 1
+fi
+
+head_value=$(git -C "$lab_dir" show HEAD:app.txt)
+index_value=$(git -C "$lab_dir" show :app.txt)
+working_value=$(<"$lab_dir/app.txt")
+status_value=$(git -C "$lab_dir" status --short --untracked-files=no -- app.txt)
+
+[[ "$head_value" == "version=1" ]] || { echo "HEAD mismatch: $head_value" >&2; exit 1; }
+[[ "$index_value" == "version=2" ]] || { echo "index mismatch: $index_value" >&2; exit 1; }
+[[ "$working_value" == "version=3" ]] || { echo "working tree mismatch: $working_value" >&2; exit 1; }
+[[ "$status_value" == "MM app.txt" ]] || { echo "status mismatch: $status_value" >&2; exit 1; }
+
+printf 'ok: HEAD=version=1, Index=version=2, Working Tree=version=3, Status=MM app.txt\n'

--- a/scripts/check-docs.py
+++ b/scripts/check-docs.py
@@ -30,6 +30,8 @@ DOC_ROOTS = [
     "08-templates",
     "09-resources",
     "10-company-practices",
+    "interactive",
+    "labs",
 ]
 
 SKIP_PARTS = {
@@ -90,42 +92,46 @@ def is_skipped(path: Path) -> bool:
     return any(rel_path == part or rel_path.startswith(part + "/") for part in SKIP_PARTS)
 
 
-def markdown_files() -> list[Path]:
+def content_files() -> list[Path]:
     files: list[Path] = []
     for item in DOC_ROOTS:
         path = REPO_ROOT / item
         if not path.exists():
             continue
-        if path.is_file() and path.suffix == ".md" and not is_skipped(path):
+        if path.is_file() and path.suffix in {".html", ".md"} and not is_skipped(path):
             files.append(path)
         elif path.is_dir():
             files.extend(
-                p for p in path.rglob("*.md")
-                if p.is_file() and not is_skipped(p)
+                p for p in path.rglob("*")
+                if p.is_file() and p.suffix in {".html", ".md"} and not is_skipped(p)
             )
     return sorted(set(files))
 
 
 def check_local_links(files: list[Path]) -> list[str]:
-    pattern = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+    patterns = [
+        re.compile(r"\[[^\]]+\]\(([^)]+)\)"),
+        re.compile(r"href=[\"']([^\"']+)[\"']"),
+    ]
     errors: list[str] = []
 
     for path in files:
         text = path.read_text(encoding="utf-8")
-        for match in pattern.finditer(text):
-            raw = match.group(1).strip()
-            if not raw or raw.startswith(("#", "http://", "https://", "mailto:")):
-                continue
+        for pattern in patterns:
+            for match in pattern.finditer(text):
+                raw = match.group(1).strip()
+                if not raw or raw.startswith(("#", "http://", "https://", "mailto:")):
+                    continue
 
-            target = raw.split("#", 1)[0]
-            target = urllib.parse.unquote(target)
-            if target.startswith("<") and target.endswith(">"):
-                target = target[1:-1]
+                target = raw.split("#", 1)[0]
+                target = urllib.parse.unquote(target)
+                if target.startswith("<") and target.endswith(">"):
+                    target = target[1:-1]
 
-            resolved = (path.parent / target).resolve()
-            if not resolved.exists():
-                line = text[:match.start()].count("\n") + 1
-                errors.append(f"{rel(path)}:{line}: broken local link: {raw}")
+                resolved = (path.parent / target).resolve()
+                if not resolved.exists():
+                    line = text[:match.start()].count("\n") + 1
+                    errors.append(f"{rel(path)}:{line}: broken local link: {raw}")
 
     return errors
 
@@ -169,7 +175,7 @@ def check_tracked_files(files: list[Path]) -> list[str]:
 
 
 def main() -> int:
-    files = markdown_files()
+    files = content_files()
     checks = {
         "local links": check_local_links(files),
         "forbidden text": check_forbidden_text(files),
@@ -189,7 +195,7 @@ def main() -> int:
     if failed:
         return 1
 
-    print(f"checked {len(files)} markdown files")
+    print(f"checked {len(files)} documentation files")
     return 0
 
 

--- a/scripts/check-links.py
+++ b/scripts/check-links.py
@@ -34,6 +34,7 @@ DOC_ROOTS = [
     "08-templates",
     "09-resources",
     "10-company-practices",
+    "labs",
 ]
 
 SKIP_PARTS = {


### PR DESCRIPTION
## What changed

- 新增中英文《快照与状态》旗舰样板章节
- 新增零依赖交互演示，展示 HEAD、Index、Working Tree 的五种状态
- 新增可在临时仓库运行的实验、预期输出和自验证脚本
- 补充导航入口，并让文档检查覆盖交互页与实验目录
- 在 GitHub Actions 中运行实验验证

## Why

把 Git 心智模型的第一章做成可完整评审的纵向样板，验证“原理讲解 + 交互图 + 临时仓库实验 + 故障恢复 + AI Agent 场景”的内容形式。

## Validation

- `python3 scripts/check-docs.py`
- `python3 scripts/check-links.py --no-external`
- `bash labs/git-mental-model/01-snapshots-and-state/test.sh`
- `git diff --check`
- 桌面端与移动端浏览器交互、键盘操作、控制台检查

## AI assistance

- OpenAI Codex：内容设计、实现、验证与提交整理
- Claude Opus：交互页面实现辅助

## Human review

请重点检查中英文文章表达、交互页状态演示，以及实验命令和预期输出。
