### PR TITLE
docs: 新增 Git Index 心智模型第三章

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -25,3 +25,4 @@ jobs:
         run: |
           bash labs/git-mental-model/01-snapshots-and-state/test.sh
           bash labs/git-mental-model/02-object-graph/test.sh
+          bash labs/git-mental-model/03-index/test.sh

--- a/01-getting-started/01-getting-started_en/git-learning-path_en.md
+++ b/01-getting-started/01-getting-started_en/git-learning-path_en.md
@@ -19,8 +19,9 @@ Recommended reading:
 1. [Git Mental Model](git-mental-model_en.md)
 2. [Snapshots and State: HEAD, Index, and Working Tree](git-mental-model-01-snapshots_en.md)
 3. [The Object Graph: Blobs, Trees, and Commits](git-mental-model-02-object-graph_en.md)
-4. [Git Basic Commands](git-basic-commands_en.md)
-5. [Why Use Git](why-git_en.md)
+4. [The Index Is the Next Commit Draft](git-mental-model-03-index_en.md)
+5. [Git Basic Commands](git-basic-commands_en.md)
+6. [Why Use Git](why-git_en.md)
 
 Mastery Goals:
 

--- a/01-getting-started/01-getting-started_en/git-mental-model-03-index_en.md
+++ b/01-getting-started/01-getting-started_en/git-mental-model-03-index_en.md
@@ -1,0 +1,292 @@
+# Git Mental Model 03: The Index Is the Next Commit Draft
+
+English | [中文](../git-mental-model-03-index.md) | [Interactive demo](../../interactive/git-mental-model/index-as-draft.html) | [Runnable lab](../../labs/git-mental-model/03-index/README.md)
+
+When an AI agent changes ten files but says, "I will commit only two," the working tree is not enough evidence. The text explanation is not enough either. The index decides what the next commit will contain.
+
+The index is also called the staging area. Calling it "the next commit draft" is useful, but one lower-level fact matters: it is usually stored in the binary `.git/index` file. A normal entry records a path, mode, blob object ID, stage number, and filesystem metadata used for performance. File content lives in blobs in the object database; the index references that content by object ID.
+
+This chapter answers three questions:
+
+1. What does `git add` actually change?
+2. How can one file contain staged and unstaged changes at the same time?
+3. Why does the index contain stages 1, 2, and 3 during a conflict?
+
+## The short version
+
+```text
+HEAD                    Index                         Working Tree
+previous commit         next commit draft             current disk files
+
+app.txt v1  --add -p--> app.txt v2  --edit again-->   app.txt v3
+```
+
+- `git add <path>` writes the selected current content as a blob and updates the index entry.
+- `git commit` writes trees from stage-0 index entries, then creates a commit.
+- `git diff --cached` compares `HEAD` with the index. It is the closest answer to "what will the next commit change?"
+- `git diff` compares the index with the working tree and shows changes still outside the draft.
+- In `git status --short`, the first column describes the index relative to `HEAD`; the second describes the working tree relative to the index.
+- A conflicted path temporarily has no normal stage-0 entry. The index keeps the merge base, ours, and theirs as candidates for resolution.
+
+A change visible in the working tree may therefore be absent from the next commit. Content already deleted or rewritten in the working tree may also remain in the index as a different version.
+
+## What an index entry records
+
+Run:
+
+```bash
+git ls-files --stage
+```
+
+The normal output shape is:
+
+```text
+<mode> <object-id> <stage>\t<path>
+```
+
+For example:
+
+```text
+100644 42c4cc2... 0	app.txt
+```
+
+This means:
+
+- `100644`: a regular non-executable file mode.
+- `42c4cc2...`: the blob object ID referenced by the index.
+- `0`: a normal entry uses stage 0.
+- `app.txt`: the path relative to the repository root.
+
+The index also contains a stat cache and other performance fields. For deciding what the next commit contains, the important fields are the path, mode, object ID, and stage.
+
+## `git add` updates one path snapshot
+
+Suppose `app.txt` in `HEAD` contains:
+
+```text
+owner=team
+deploy=off
+```
+
+Change `owner` to `agent`, then run:
+
+```bash
+git add app.txt
+```
+
+Git writes or reuses a blob for the current content and points the index entry for `app.txt` to it. If you then change `deploy` to `on`, the index is not updated automatically.
+
+Three content versions can now coexist:
+
+```text
+HEAD          owner=team   deploy=off
+Index         owner=agent  deploy=off
+Working Tree  owner=agent  deploy=on
+```
+
+Inspect the two different comparisons:
+
+```bash
+git diff --cached -- app.txt
+git diff -- app.txt
+```
+
+The first command shows only the `owner` change. The second shows only the `deploy` change.
+
+## Partial staging: split one file into two review scopes
+
+`git add -p` presents each diff hunk and lets you choose which hunks enter the index:
+
+```bash
+git add -p app.txt
+```
+
+Common answers:
+
+- `y`: stage this hunk.
+- `n`: skip this hunk.
+- `s`: try to split this hunk further.
+- `e`: edit the patch manually, for users who can validate patch semantics precisely.
+- `q`: quit without processing later hunks.
+
+After partial staging, `git status --short` may show:
+
+```text
+MM app.txt
+```
+
+The first `M` means the index differs from `HEAD`. The second means the working tree still differs from the index. Git is not counting one edit twice; each comparison boundary found its own difference.
+
+Before committing, inspect at least:
+
+```bash
+git diff --cached
+git status --short
+```
+
+If one behavior spans several hunks, splitting them may create a commit that does not build or is behaviorally incomplete. Partial staging should improve commit clarity without breaking change atomicity.
+
+## Conflict stages: three candidate versions in the index
+
+Normal paths use stage 0. During a content conflict, one path can have up to three higher-stage entries:
+
+```text
+stage 1  merge base, the common ancestor
+stage 2  ours, the current branch version
+stage 3  theirs, the merged branch version
+```
+
+Inspect them with:
+
+```bash
+git ls-files --unmerged
+git show :1:conflict.txt
+git show :2:conflict.txt
+git show :3:conflict.txt
+```
+
+Example output:
+
+```text
+100644 8227059... 1	conflict.txt
+100644 c3efd06... 2	conflict.txt
+100644 d17b9a9... 3	conflict.txt
+```
+
+Resolve the conflict in the working tree, then run:
+
+```bash
+git add conflict.txt
+```
+
+Git removes stages 1, 2, and 3 and creates a stage-0 entry for the resolution. Here, `git add` communicates two facts: accept the current file content and mark this path resolved.
+
+The ours/theirs description above applies to a regular merge. A rebase changes the replay perspective, so confirm the active operation before using `--ours` or `--theirs`.
+
+## Interactive demo
+
+[Open the Index Is the Next Commit Draft interactive](../../interactive/git-mental-model/index-as-draft.html). The page drives every command, `git status --short` result, index entry, and commit preview from one state model.
+
+Start a static server from the repository root:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then visit:
+
+```text
+http://localhost:8000/interactive/git-mental-model/index-as-draft.html
+```
+
+When finished, press `Ctrl-C` in the terminal running the server.
+
+## Run the experiment in a temporary repository
+
+The lab creates an isolated temporary repository and does not modify this project:
+
+```bash
+cd labs/git-mental-model/03-index
+lab_path=$(bash setup.sh)
+bash verify.sh "$lab_path"
+bash cleanup.sh "$lab_path"
+```
+
+Run the complete self-test with:
+
+```bash
+bash labs/git-mental-model/03-index/test.sh
+```
+
+The final repository preserves three states that can be inspected together:
+
+```text
+MM app.txt
+UU conflict.txt
+ M settings.ini
+```
+
+- The first hunk in `app.txt` is in the index; the second remains only in the working tree.
+- `conflict.txt` has stages 1, 2, and 3 in the index.
+- `settings.ini` is changed only in the working tree and is outside the next commit draft.
+
+See [expected.txt](../../labs/git-mental-model/03-index/expected.txt) for the full expected state.
+
+## Recovery: an agent staged an unrelated file
+
+Suppose an agent ran `git add -A` and staged the local configuration in `settings.ini`.
+
+Inspect the draft first:
+
+```bash
+git status --short
+git diff --cached -- settings.ini
+```
+
+After confirming that the path should not be committed, restore only the index:
+
+```bash
+git restore --staged -- settings.ini
+git status --short
+```
+
+By default, `git restore --staged` restores the index from `HEAD` while keeping the working-tree edit. It fits the "unstage but keep my local work" case.
+
+Do not use this just to unstage a path:
+
+```bash
+git reset --hard
+```
+
+`reset --hard` also overwrites the working tree and can destroy uncommitted content. When only the draft needs adjustment, use `git restore --staged` with an explicit path.
+
+## Common misconceptions
+
+### "The index is only a list of filenames to commit"
+
+An index entry also records a mode, object ID, and stage. It identifies the specific content version prepared for each path.
+
+### "After `git add`, later edits automatically enter the commit"
+
+Each `git add` updates only the selected content at that moment. Later edits remain in the working tree until staged again.
+
+### "`git commit -a` equals `git add -A && git commit`"
+
+`git commit -a` automatically stages changes and deletions to tracked files, but it does not include new untracked files. It also reduces the opportunity to inspect the index separately before committing.
+
+### "Conflict markers exist only in the working-tree file"
+
+The working tree displays conflict markers while the index stores candidate blobs in stages 1, 2, and 3. `git add` restores stage 0 after resolution.
+
+### "Unstaging deletes my edit"
+
+`git restore --staged -- <path>` changes only the index. The working tree stays unchanged unless `--worktree` is also specified.
+
+## Why this matters for AI agents
+
+An agent may edit many files and may run an overly broad `git add -A`. Inspect the real index when accepting an agent-authored commit:
+
+```bash
+git status --short
+git diff --cached --stat
+git diff --cached
+git ls-files --unmerged
+```
+
+Recommended acceptance checks:
+
+1. `git diff --cached` contains only paths and hunks required by the task.
+2. `git ls-files --unmerged` produces no output.
+3. Remaining working-tree edits have a known owner and are not mistaken for committed work.
+4. A partially staged commit can still be built, tested, or explained independently.
+5. The agent's claimed commit scope matches the actual index.
+
+For an AI agent, the index is the smallest commit-permission boundary. Inspecting it is more reliable than asking the agent what it plans to commit.
+
+## Further reading
+
+- [Git index format](https://git-scm.com/docs/index-format)
+- [git ls-files](https://git-scm.com/docs/git-ls-files)
+- [git add](https://git-scm.com/docs/git-add)
+- [git restore](https://git-scm.com/docs/git-restore)
+- [Previous chapter: The Object Graph](git-mental-model-02-object-graph_en.md)

--- a/01-getting-started/01-getting-started_en/git-mental-model_en.md
+++ b/01-getting-started/01-getting-started_en/git-mental-model_en.md
@@ -8,10 +8,13 @@ This page is the entry point to the Git Mental Model series. The four-area model
 
 1. [Snapshots and State: HEAD, Index, and Working Tree](git-mental-model-01-snapshots_en.md)
 2. [The Object Graph: Blobs, Trees, and Commits](git-mental-model-02-object-graph_en.md)
+3. [The Index Is the Next Commit Draft](git-mental-model-03-index_en.md)
 
 The first chapter uses three versions of one file to show what `git add` and `git commit` actually record. It includes an [interactive demo](../../interactive/git-mental-model/snapshots-and-state.html) and a [runnable lab](../../labs/git-mental-model/01-snapshots-and-state/README.md).
 
 The second chapter follows a commit into the object database, separates the responsibilities of blobs, trees, and commits, and includes an [object-graph interactive](../../interactive/git-mental-model/object-graph.html) and a [runnable lab](../../labs/git-mental-model/02-object-graph/README.md).
+
+The third chapter goes deeper into the index through partial staging, `git diff --cached`, safe unstaging, and conflict stages 1, 2, and 3. It includes an [index-draft interactive](../../interactive/git-mental-model/index-as-draft.html) and a [runnable lab](../../labs/git-mental-model/03-index/README.md).
 
 ## Four-area quick model
 

--- a/01-getting-started/git-learning-path.md
+++ b/01-getting-started/git-learning-path.md
@@ -17,8 +17,9 @@ Git 不适合靠背命令学习。
 1. [Git 心智模型](git-mental-model.md)
 2. [快照与状态：HEAD、Index 与 Working Tree](git-mental-model-01-snapshots.md)
 3. [对象图：blob、tree 与 commit](git-mental-model-02-object-graph.md)
-4. [Git 基础命令](git-basic-commands.md)
-5. [为什么使用 Git](why-git.md)
+4. [Index 是下一次 commit 的草稿](git-mental-model-03-index.md)
+5. [Git 基础命令](git-basic-commands.md)
+6. [为什么使用 Git](why-git.md)
 
 掌握目标：
 

--- a/01-getting-started/git-mental-model-03-index.md
+++ b/01-getting-started/git-mental-model-03-index.md
@@ -1,0 +1,292 @@
+# Git 心智模型 03：Index 是下一次 commit 的草稿
+
+[English](01-getting-started_en/git-mental-model-03-index_en.md) | [交互演示](../interactive/git-mental-model/index-as-draft.html) | [可运行实验](../labs/git-mental-model/03-index/README.md)
+
+当 AI Agent 修改了十个文件，却说“我只会提交其中两个”时，不能只看 Working Tree，也不能只相信文字说明。真正决定下一次 commit 内容的是 Index。
+
+Index 也叫 staging area。把它理解成“下一次 commit 的草稿”很实用，但还要补上一层底层事实：它通常存放在 `.git/index` 这个二进制文件中，普通条目记录路径、模式、blob 对象 ID、stage 号和用于性能优化的文件系统元数据。文件内容位于对象库中的 blob，Index 通过对象 ID 引用这些内容。
+
+本章解决三个问题：
+
+1. `git add` 到底改变了什么。
+2. 同一个文件为什么可以同时有 staged 和 unstaged 改动。
+3. 合并冲突时，Index 为什么会出现 stage 1、2、3。
+
+## 先看结论
+
+```text
+HEAD                    Index                         Working Tree
+上一次 commit           下一次 commit 的草稿          当前磁盘文件
+
+app.txt v1  --add -p--> app.txt v2  --继续编辑-->      app.txt v3
+```
+
+- `git add <path>` 把该路径当前选中的内容写成 blob，并更新 Index 条目。
+- `git commit` 根据 Index 的 stage 0 条目生成 tree，再创建 commit。
+- `git diff --cached` 比较 `HEAD` 与 Index，最接近“下一次 commit 会改变什么”。
+- `git diff` 比较 Index 与 Working Tree，显示尚未进入草稿的修改。
+- `git status --short` 第一列描述 Index 相对 `HEAD` 的变化，第二列描述 Working Tree 相对 Index 的变化。
+- 冲突路径暂时没有正常的 stage 0 条目，会保留共同祖先、ours、theirs 三个版本供你解决。
+
+因此，Working Tree 里看得到的修改，不一定会进入下一次 commit；Working Tree 里已经删除或改写的内容，也可能仍以另一个版本存在于 Index。
+
+## Index 条目记录什么
+
+运行：
+
+```bash
+git ls-files --stage
+```
+
+普通输出格式是：
+
+```text
+<mode> <object-id> <stage>\t<path>
+```
+
+例如：
+
+```text
+100644 42c4cc2... 0	app.txt
+```
+
+这表示：
+
+- `100644`：普通非可执行文件的模式。
+- `42c4cc2...`：Index 引用的 blob 对象 ID。
+- `0`：正常条目使用 stage 0。
+- `app.txt`：相对仓库根目录的路径。
+
+Index 还包含 stat cache 等性能字段。日常判断下一次 commit 内容时，最重要的是路径、模式、对象 ID 和 stage。
+
+## `git add` 更新的是一份路径快照
+
+假设 `app.txt` 在 `HEAD` 中是：
+
+```text
+owner=team
+deploy=off
+```
+
+把 `owner` 改成 `agent` 后执行：
+
+```bash
+git add app.txt
+```
+
+Git 会为当前内容写入或复用 blob，并让 Index 的 `app.txt` 指向这个 blob。之后继续把 `deploy` 改成 `on`，不会自动再次更新 Index。
+
+此时可能同时存在三份内容：
+
+```text
+HEAD          owner=team   deploy=off
+Index         owner=agent  deploy=off
+Working Tree  owner=agent  deploy=on
+```
+
+查看两段不同的差异：
+
+```bash
+git diff --cached -- app.txt
+git diff -- app.txt
+```
+
+第一条只显示 `owner` 的变化，第二条只显示 `deploy` 的变化。
+
+## 部分暂存：一个文件拆成两个审查范围
+
+`git add -p` 会逐个展示 diff hunk，并让你选择哪些 hunk 进入 Index：
+
+```bash
+git add -p app.txt
+```
+
+常用回答：
+
+- `y`：暂存当前 hunk。
+- `n`：跳过当前 hunk。
+- `s`：尝试把当前 hunk 继续拆分。
+- `e`：手工编辑补丁，适合能准确判断补丁语义的用户。
+- `q`：退出，后续 hunk 不再处理。
+
+部分暂存后，`git status --short` 可能显示：
+
+```text
+MM app.txt
+```
+
+第一个 `M` 表示 Index 相对 `HEAD` 已修改，第二个 `M` 表示 Working Tree 相对 Index 还有修改。这里包含两个比较边界，各自发现了一份差异。
+
+提交前至少检查：
+
+```bash
+git diff --cached
+git status --short
+```
+
+如果业务逻辑跨越多个 hunk，拆开提交可能造成某个 commit 无法构建或行为不完整。部分暂存服务于清晰提交，不能破坏变更的原子性。
+
+## 冲突 stages：Index 暂存三个候选版本
+
+普通路径在 Index 中使用 stage 0。发生内容冲突时，一个路径会出现最多三个高 stage 条目：
+
+```text
+stage 1  merge base，共同祖先版本
+stage 2  ours，当前分支版本
+stage 3  theirs，被合入分支版本
+```
+
+检查命令：
+
+```bash
+git ls-files --unmerged
+git show :1:conflict.txt
+git show :2:conflict.txt
+git show :3:conflict.txt
+```
+
+示意输出：
+
+```text
+100644 8227059... 1	conflict.txt
+100644 c3efd06... 2	conflict.txt
+100644 d17b9a9... 3	conflict.txt
+```
+
+解决 Working Tree 中的冲突并执行：
+
+```bash
+git add conflict.txt
+```
+
+Git 会移除 stage 1、2、3，为解决结果建立新的 stage 0 条目。这里的 `git add` 同时表达两个事实：接受当前文件内容，并把该路径标记为已解决。
+
+上面的 ours/theirs 解释适用于普通 merge。rebase 会改变变更重放的视角，使用 `--ours` 或 `--theirs` 前要重新确认当前操作语义。
+
+## 交互演示
+
+[打开“Index 是下一次 commit 的草稿”交互演示](../interactive/git-mental-model/index-as-draft.html)。页面把每一步命令、`git status --short`、Index 条目和提交预览绑定到同一份状态数据。
+
+从仓库根目录启动静态服务器：
+
+```bash
+python3 -m http.server 8000
+```
+
+然后访问：
+
+```text
+http://localhost:8000/interactive/git-mental-model/index-as-draft.html
+```
+
+查看完成后，在运行服务器的终端按 `Ctrl-C` 退出。
+
+## 在临时仓库运行实验
+
+实验会创建一个独立临时仓库，不修改当前项目：
+
+```bash
+cd labs/git-mental-model/03-index
+lab_path=$(bash setup.sh)
+bash verify.sh "$lab_path"
+bash cleanup.sh "$lab_path"
+```
+
+一次运行完整自测：
+
+```bash
+bash labs/git-mental-model/03-index/test.sh
+```
+
+实验最终保留三个可同时检查的状态：
+
+```text
+MM app.txt
+UU conflict.txt
+ M settings.ini
+```
+
+- `app.txt` 的第一个 hunk 已进入 Index，第二个 hunk 只在 Working Tree。
+- `conflict.txt` 在 Index 中保存 stage 1、2、3。
+- `settings.ini` 只在 Working Tree 改动，不属于下一次 commit 草稿。
+
+完整预期说明见 [expected.txt](../labs/git-mental-model/03-index/expected.txt)。
+
+## 故障恢复：Agent 暂存了无关文件
+
+假设 Agent 执行了 `git add -A`，把本地配置 `settings.ini` 一起放进 Index。
+
+先检查草稿：
+
+```bash
+git status --short
+git diff --cached -- settings.ini
+```
+
+确认该路径不应提交后，只恢复 Index：
+
+```bash
+git restore --staged -- settings.ini
+git status --short
+```
+
+`git restore --staged` 默认用 `HEAD` 中的版本恢复 Index，Working Tree 的修改保持不变。这很适合“取消暂存但保留本地编辑”的场景。
+
+不要为了取消暂存直接使用：
+
+```bash
+git reset --hard
+```
+
+`reset --hard` 还会覆盖 Working Tree，可能丢失尚未提交的内容。只需要调整草稿时，应使用带明确路径的 `git restore --staged`。
+
+## 常见误解
+
+### “Index 只是待提交文件名列表”
+
+Index 条目还记录模式、对象 ID 和 stage。它描述的是每个路径准备提交的具体内容版本。
+
+### “`git add` 以后，文件后续修改也会自动进入提交”
+
+每次 `git add` 只更新当时选中的内容。后续编辑仍在 Working Tree，需要再次暂存。
+
+### “`git commit -a` 等价于 `git add -A && git commit`”
+
+`git commit -a` 会自动暂存已跟踪文件的修改和删除，但不会包含新的未跟踪文件。它也减少了提交前单独审查 Index 的机会。
+
+### “冲突标记只存在于 Working Tree 文件里”
+
+Working Tree 展示冲突标记，Index 同时保存 stage 1、2、3 的候选 blob。解决后 `git add` 才会恢复 stage 0。
+
+### “取消暂存会删除我的修改”
+
+`git restore --staged -- <path>` 只修改 Index。没有同时指定 `--worktree` 时，Working Tree 保持不变。
+
+## 在 AI Agent 场景中的意义
+
+Agent 可能修改许多文件，也可能运行范围过大的 `git add -A`。验收 Agent 提交时，应该检查真实 Index：
+
+```bash
+git status --short
+git diff --cached --stat
+git diff --cached
+git ls-files --unmerged
+```
+
+推荐放行规则：
+
+1. `git diff --cached` 只包含当前任务需要的路径和 hunk。
+2. `git ls-files --unmerged` 没有输出。
+3. Working Tree 中保留的改动已经明确归属，不会被误认为已提交。
+4. 部分暂存后的提交仍能独立构建、测试或解释。
+5. Agent 声明的提交范围与 Index 的真实内容一致。
+
+对 AI Agent 来说，Index 是提交权限的最小边界。检查它，比询问 Agent “你准备提交什么”更可靠。
+
+## 延伸阅读
+
+- [Git index format](https://git-scm.com/docs/index-format)
+- [git ls-files](https://git-scm.com/docs/git-ls-files)
+- [git add](https://git-scm.com/docs/git-add)
+- [git restore](https://git-scm.com/docs/git-restore)
+- [上一章：对象图](git-mental-model-02-object-graph.md)

--- a/01-getting-started/git-mental-model.md
+++ b/01-getting-started/git-mental-model.md
@@ -8,10 +8,13 @@
 
 1. [快照与状态：HEAD、Index 与 Working Tree](git-mental-model-01-snapshots.md)
 2. [对象图：blob、tree 与 commit](git-mental-model-02-object-graph.md)
+3. [Index 是下一次 commit 的草稿](git-mental-model-03-index.md)
 
 第一章通过同一个文件的三个版本，演示 `git add` 和 `git commit` 实际记录什么，并提供[交互演示](../interactive/git-mental-model/snapshots-and-state.html)和[可运行实验](../labs/git-mental-model/01-snapshots-and-state/README.md)。
 
 第二章沿 commit 进入对象库，拆解 blob、tree 与 commit 的责任边界，并提供[对象图交互演示](../interactive/git-mental-model/object-graph.html)和[可运行实验](../labs/git-mental-model/02-object-graph/README.md)。
+
+第三章深入 Index，演示部分暂存、`git diff --cached`、安全取消暂存与冲突 stage 1、2、3，并提供[Index 草稿交互演示](../interactive/git-mental-model/index-as-draft.html)和[可运行实验](../labs/git-mental-model/03-index/README.md)。
 
 ## 四区域快速模型
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ v2.0 版本的定位是：
 2. [Git 心智模型](01-getting-started/git-mental-model.md)
 3. [快照与状态：HEAD、Index 与 Working Tree](01-getting-started/git-mental-model-01-snapshots.md)
 4. [对象图：blob、tree 与 commit](01-getting-started/git-mental-model-02-object-graph.md)
-5. [Git 基础命令](01-getting-started/git-basic-commands.md)
-6. [日常 Git 命令](02-daily-workflow/everyday-git-commands.md)
+5. [Index 是下一次 commit 的草稿](01-getting-started/git-mental-model-03-index.md)
+6. [Git 基础命令](01-getting-started/git-basic-commands.md)
+7. [日常 Git 命令](02-daily-workflow/everyday-git-commands.md)
 
 ### 日常开发路径
 

--- a/README_en.md
+++ b/README_en.md
@@ -50,8 +50,9 @@ Therefore, v2.0 upgrades this repository into:
 2.  [Git Mental Model](01-getting-started/01-getting-started_en/git-mental-model_en.md)
 3.  [Snapshots and State: HEAD, Index, and Working Tree](01-getting-started/01-getting-started_en/git-mental-model-01-snapshots_en.md)
 4.  [The Object Graph: Blobs, Trees, and Commits](01-getting-started/01-getting-started_en/git-mental-model-02-object-graph_en.md)
-5.  [Git Basic Commands](01-getting-started/01-getting-started_en/git-basic-commands_en.md)
-6.  [Everyday Git Commands](02-daily-workflow/02-daily-workflow_en/everyday-git-commands_en.md)
+5.  [The Index Is the Next Commit Draft](01-getting-started/01-getting-started_en/git-mental-model-03-index_en.md)
+6.  [Git Basic Commands](01-getting-started/01-getting-started_en/git-basic-commands_en.md)
+7.  [Everyday Git Commands](02-daily-workflow/02-daily-workflow_en/everyday-git-commands_en.md)
 
 ### Daily Development Path
 

--- a/interactive/git-mental-model/index-as-draft.html
+++ b/interactive/git-mental-model/index-as-draft.html
@@ -1,0 +1,562 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Explore how Git's index becomes the next commit draft through partial staging, recovery, and conflict stages.">
+  <title>Index as the next commit draft | Git Mental Model</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f3f0e9;
+      --panel: #fffdf8;
+      --panel-2: #ebe6dc;
+      --ink: #25231f;
+      --muted: #6f6a60;
+      --line: #d8d1c4;
+      --accent: #c55426;
+      --accent-soft: #f5d8c8;
+      --blue: #276b8a;
+      --blue-soft: #d8eaf1;
+      --green: #34745c;
+      --green-soft: #dbece4;
+      --violet: #72568f;
+      --violet-soft: #e9def2;
+      --danger: #a63d32;
+      --shadow: 0 16px 44px rgba(45, 38, 28, .1);
+      --ui: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #171715;
+        --panel: #211f1c;
+        --panel-2: #2b2823;
+        --ink: #f1ede5;
+        --muted: #aaa398;
+        --line: #403b34;
+        --accent: #ef8758;
+        --accent-soft: #4a2d21;
+        --blue: #75b7d4;
+        --blue-soft: #203946;
+        --green: #73b597;
+        --green-soft: #203a30;
+        --violet: #b79ad0;
+        --violet-soft: #382d43;
+        --danger: #ef8e84;
+        --shadow: 0 18px 50px rgba(0, 0, 0, .25);
+      }
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at 8% 4%, color-mix(in srgb, var(--accent) 12%, transparent), transparent 31rem),
+        var(--bg);
+      color: var(--ink);
+      font-family: var(--ui);
+    }
+    button, a { -webkit-tap-highlight-color: transparent; }
+    button { font: inherit; }
+    code, pre { font-family: var(--mono); }
+    a { color: inherit; }
+
+    .shell { width: min(1500px, calc(100% - 32px)); margin: 0 auto; padding: 30px 0 44px; }
+    .topbar { display: flex; align-items: flex-start; justify-content: space-between; gap: 28px; margin-bottom: 22px; }
+    .kicker { margin: 0 0 8px; color: var(--accent); font: 700 12px/1 var(--mono); letter-spacing: .12em; text-transform: uppercase; }
+    h1 { margin: 0; max-width: 820px; font-size: clamp(29px, 4vw, 54px); line-height: .98; letter-spacing: -.045em; }
+    .lead { max-width: 760px; margin: 15px 0 0; color: var(--muted); font-size: 16px; line-height: 1.65; }
+    .toolbar { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+    .tool {
+      border: 1px solid var(--line); border-radius: 6px; padding: 9px 11px; background: var(--panel);
+      color: var(--ink); cursor: pointer; box-shadow: 0 4px 14px rgba(0,0,0,.04);
+    }
+    .tool:hover { border-color: var(--accent); }
+    .tool:focus-visible, .step:focus-visible { outline: 3px solid color-mix(in srgb, var(--accent) 35%, transparent); outline-offset: 2px; }
+
+    .progress { height: 3px; background: var(--line); margin: 0 0 18px; overflow: hidden; }
+    .progress > span { display: block; height: 100%; width: 12.5%; background: var(--accent); transition: width 250ms ease; }
+    .workspace { display: grid; grid-template-columns: 250px minmax(0, 1fr); gap: 16px; align-items: start; }
+    .rail { position: sticky; top: 16px; border: 1px solid var(--line); background: color-mix(in srgb, var(--panel) 92%, transparent); box-shadow: var(--shadow); }
+    .rail-head { padding: 16px; border-bottom: 1px solid var(--line); display: flex; justify-content: space-between; color: var(--muted); font: 600 12px/1 var(--mono); }
+    .steps { padding: 7px; display: grid; gap: 3px; }
+    .step {
+      display: grid; grid-template-columns: 28px 1fr; align-items: center; gap: 9px; width: 100%; padding: 10px;
+      border: 1px solid transparent; border-radius: 5px; background: transparent; color: var(--muted); text-align: left; cursor: pointer;
+    }
+    .step:hover { background: var(--panel-2); color: var(--ink); }
+    .step[aria-current="step"] { background: var(--accent-soft); border-color: color-mix(in srgb, var(--accent) 34%, var(--line)); color: var(--ink); }
+    .step-num { font: 700 11px/1 var(--mono); color: var(--accent); }
+    .step-label { font-size: 13px; font-weight: 700; line-height: 1.25; }
+
+    .stage { min-width: 0; display: grid; gap: 16px; }
+    .card { border: 1px solid var(--line); background: var(--panel); box-shadow: var(--shadow); }
+    .card-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 13px 16px; border-bottom: 1px solid var(--line); }
+    .card-title { margin: 0; font-size: 13px; letter-spacing: .02em; }
+    .badge { border-radius: 99px; padding: 5px 9px; color: var(--accent); background: var(--accent-soft); font: 700 11px/1 var(--mono); }
+
+    .terminal { background: #141516; color: #ece9e1; border-color: #2d2f30; box-shadow: 0 18px 50px rgba(0,0,0,.22); }
+    .terminal .card-head { border-color: #303233; }
+    .dots { display: flex; gap: 6px; }
+    .dots i { width: 8px; height: 8px; border-radius: 50%; background: #5a5d5f; }
+    .dots i:first-child { background: #d56a4d; }
+    .dots i:nth-child(2) { background: #d6a84c; }
+    .dots i:last-child { background: #62a479; }
+    .terminal-grid { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(240px, .85fr); }
+    .terminal-pane { min-width: 0; padding: 17px; }
+    .terminal-pane + .terminal-pane { border-left: 1px solid #303233; }
+    .terminal-label { margin: 0 0 10px; color: #8f9698; font: 700 10px/1 var(--mono); letter-spacing: .1em; text-transform: uppercase; }
+    pre { margin: 0; white-space: pre-wrap; overflow-wrap: anywhere; font-size: 12px; line-height: 1.65; }
+    .prompt { color: #84c69f; }
+    #command::first-line { color: #f2d48b; }
+
+    .views { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); border-top: 1px solid var(--line); }
+    .view { min-width: 0; padding: 16px; }
+    .view + .view { border-left: 1px solid var(--line); }
+    .view-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 13px; }
+    .view-name { font-weight: 800; font-size: 15px; }
+    .view-note { color: var(--muted); font: 10px/1 var(--mono); text-align: right; }
+    .file-list { display: grid; gap: 8px; }
+    .file {
+      min-height: 84px; padding: 10px; border: 1px solid var(--line); border-radius: 5px; background: var(--bg);
+      transition: border-color 180ms ease, transform 180ms ease;
+    }
+    .file.changed { border-color: var(--accent); transform: translateY(-1px); }
+    .file-top { display: flex; justify-content: space-between; gap: 8px; margin-bottom: 8px; }
+    .file-path { font: 700 11px/1.2 var(--mono); }
+    .file-tag { color: var(--muted); font: 700 10px/1 var(--mono); }
+    .file pre { color: var(--muted); font-size: 10px; line-height: 1.45; }
+
+    .lower { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(300px, .85fr); gap: 16px; }
+    .index-wrap { overflow-x: auto; }
+    table { width: 100%; border-collapse: collapse; font: 11px/1.45 var(--mono); }
+    th, td { padding: 10px 12px; border-bottom: 1px solid var(--line); text-align: left; white-space: nowrap; }
+    th { color: var(--muted); font-size: 9px; letter-spacing: .1em; text-transform: uppercase; }
+    tbody tr:last-child td { border-bottom: 0; }
+    .stage-pill { display: inline-grid; place-items: center; width: 24px; height: 22px; border-radius: 4px; background: var(--panel-2); font-weight: 800; }
+    .stage-pill.s1 { background: var(--blue-soft); color: var(--blue); }
+    .stage-pill.s2 { background: var(--green-soft); color: var(--green); }
+    .stage-pill.s3 { background: var(--violet-soft); color: var(--violet); }
+
+    .draft { padding: 16px; }
+    .draft-empty { min-height: 125px; display: grid; place-items: center; border: 1px dashed var(--line); color: var(--muted); text-align: center; font-size: 13px; line-height: 1.55; }
+    .draft-files { display: grid; gap: 8px; }
+    .draft-file { padding: 11px; background: var(--green-soft); border-left: 3px solid var(--green); }
+    .draft-file strong { display: block; margin-bottom: 5px; font: 700 11px/1 var(--mono); }
+    .draft-file span { color: var(--muted); font-size: 12px; }
+
+    .conflict { padding: 16px; border-top: 1px solid var(--line); }
+    .conflict[hidden] { display: none; }
+    .candidates { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; }
+    .candidate { border: 1px solid var(--line); padding: 10px; min-width: 0; }
+    .candidate strong { display: block; margin-bottom: 7px; font: 700 10px/1 var(--mono); }
+    .candidate pre { font-size: 10px; color: var(--muted); }
+    .candidate.base { border-top: 3px solid var(--blue); }
+    .candidate.ours { border-top: 3px solid var(--green); }
+    .candidate.theirs { border-top: 3px solid var(--violet); }
+
+    .notes { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); border-top: 1px solid var(--line); }
+    .note { padding: 16px; min-width: 0; }
+    .note + .note { border-left: 1px solid var(--line); }
+    .note h3 { margin: 0 0 8px; font-size: 12px; }
+    .note p { margin: 0; color: var(--muted); font-size: 12px; line-height: 1.6; }
+    .note.agent h3 { color: var(--green); }
+    .note.recovery h3 { color: var(--accent); }
+    .note.misconception h3 { color: var(--violet); }
+
+    .explain { padding: 17px 19px; display: flex; align-items: flex-start; gap: 13px; }
+    .explain-mark { flex: 0 0 auto; width: 28px; height: 28px; display: grid; place-items: center; background: var(--accent); color: white; border-radius: 4px; font-weight: 900; }
+    .explain p { margin: 1px 0 0; line-height: 1.65; font-size: 14px; }
+    .footer { display: flex; justify-content: space-between; gap: 16px; margin-top: 18px; color: var(--muted); font-size: 12px; }
+    .footer-links { display: flex; flex-wrap: wrap; gap: 14px; }
+    .footer a:hover { color: var(--accent); }
+    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+
+    @media (max-width: 1000px) {
+      .workspace { grid-template-columns: 1fr; }
+      .rail { position: static; }
+      .steps { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+      .step { grid-template-columns: 20px 1fr; padding: 8px; }
+      .lower { grid-template-columns: 1fr; }
+    }
+    @media (max-width: 720px) {
+      .shell { width: min(100% - 20px, 1500px); padding-top: 18px; }
+      .topbar { display: block; }
+      .toolbar { justify-content: flex-start; margin-top: 16px; }
+      .steps { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .terminal-grid, .views, .notes { grid-template-columns: 1fr; }
+      .terminal-pane + .terminal-pane, .view + .view, .note + .note { border-left: 0; border-top: 1px solid var(--line); }
+      .candidates { grid-template-columns: 1fr; }
+      .footer { display: block; }
+      .footer-links { margin-bottom: 9px; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { scroll-behavior: auto !important; transition-duration: .01ms !important; animation-duration: .01ms !important; animation-iteration-count: 1 !important; }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <header class="topbar">
+      <div>
+        <p class="kicker">Git mental model 03</p>
+        <h1 id="page-title">Index 是下一次 commit 的草稿</h1>
+        <p class="lead" id="page-lead">沿着 8 个状态观察同一个文件如何同时拥有已暂存与未暂存修改，并看清冲突时的 stage 1、2、3。</p>
+      </div>
+      <div class="toolbar" aria-label="Page controls">
+        <button class="tool" id="prev" type="button" aria-label="Previous state">←</button>
+        <button class="tool" id="next" type="button" aria-label="Next state">→</button>
+        <button class="tool" id="lang" type="button">English</button>
+      </div>
+    </header>
+
+    <div class="progress" aria-hidden="true"><span id="progress"></span></div>
+
+    <div class="workspace">
+      <aside class="rail" aria-label="Experiment states">
+        <div class="rail-head"><span id="rail-title">状态路径</span><span id="counter">1 / 8</span></div>
+        <nav class="steps" id="steps"></nav>
+      </aside>
+
+      <section class="stage" aria-labelledby="state-title">
+        <article class="card terminal">
+          <div class="card-head">
+            <div class="dots" aria-hidden="true"><i></i><i></i><i></i></div>
+            <span class="badge" id="state-title">干净起点</span>
+          </div>
+          <div class="terminal-grid">
+            <div class="terminal-pane">
+              <p class="terminal-label" id="command-label">命令</p>
+              <pre><span class="prompt">$ </span><span id="command"></span></pre>
+            </div>
+            <div class="terminal-pane">
+              <p class="terminal-label" id="output-label">预期输出</p>
+              <pre id="output"></pre>
+            </div>
+          </div>
+        </article>
+
+        <article class="card">
+          <div class="card-head">
+            <h2 class="card-title" id="comparison-title">同一路径的三份视图</h2>
+            <span class="badge" id="status-badge">clean</span>
+          </div>
+          <div class="views" id="views"></div>
+        </article>
+
+        <div class="lower">
+          <article class="card">
+            <div class="card-head">
+              <h2 class="card-title" id="index-title">Index 条目</h2>
+              <span class="badge">git ls-files --stage</span>
+            </div>
+            <div class="index-wrap">
+              <table>
+                <thead><tr><th id="th-mode">模式</th><th>Object ID</th><th>Stage</th><th id="th-path">路径</th></tr></thead>
+                <tbody id="entries"></tbody>
+              </table>
+            </div>
+            <div class="conflict" id="conflict" hidden>
+              <div class="candidates" id="candidates"></div>
+            </div>
+          </article>
+
+          <article class="card">
+            <div class="card-head">
+              <h2 class="card-title" id="draft-title">下一次 commit 预览</h2>
+              <span class="badge">HEAD → Index</span>
+            </div>
+            <div class="draft" id="draft"></div>
+          </article>
+        </div>
+
+        <article class="card">
+          <div class="explain"><span class="explain-mark">i</span><p id="explanation"></p></div>
+          <div class="notes">
+            <div class="note misconception"><h3 id="mis-title">常见误解</h3><p id="misconception"></p></div>
+            <div class="note recovery"><h3 id="rec-title">恢复动作</h3><p id="recovery"></p></div>
+            <div class="note agent"><h3 id="agent-title">AI Agent 检查点</h3><p id="agent"></p></div>
+          </div>
+        </article>
+      </section>
+    </div>
+
+    <footer class="footer">
+      <div class="footer-links">
+        <a href="../../01-getting-started/git-mental-model-03-index.md" id="article-link">中文文章</a>
+        <a href="../../01-getting-started/01-getting-started_en/git-mental-model-03-index_en.md">English article</a>
+        <a href="../../labs/git-mental-model/03-index/README.md" id="lab-link">运行临时仓库实验</a>
+      </div>
+      <span id="keyboard-help">键盘：← → 切换，Home / End 跳转</span>
+    </footer>
+    <div class="sr-only" id="live" aria-live="polite"></div>
+  </main>
+
+  <script>
+    const TEXT = {
+      zh: {
+        title: 'Index 是下一次 commit 的草稿',
+        lead: '沿着 8 个状态观察同一个文件如何同时拥有已暂存与未暂存修改，并看清冲突时的 stage 1、2、3。',
+        rail: '状态路径', command: '命令', output: '预期输出', comparison: '同一路径的三份视图',
+        index: 'Index 条目', draft: '下一次 commit 预览', mode: '模式', path: '路径',
+        misconception: '常见误解', recovery: '恢复动作', agent: 'AI Agent 检查点',
+        article: '中文文章', lab: '运行临时仓库实验', keyboard: '键盘：← → 切换，Home / End 跳转',
+        views: [['HEAD', '上一次 commit'], ['Index', '提交草稿'], ['Working Tree', '磁盘文件']],
+        empty: 'Index 与 HEAD 相同。\n下一次 commit 暂时没有变化。', fileCount: n => `${n} 个路径进入草稿`, changed: '已改变', same: '相同',
+        announced: (n, label) => `状态 ${n}：${label}`
+      },
+      en: {
+        title: 'The index is the next commit draft',
+        lead: 'Follow eight repository states to see staged and unstaged changes coexist, then inspect conflict stages 1, 2, and 3.',
+        rail: 'State path', command: 'Command', output: 'Expected output', comparison: 'Three views of the same paths',
+        index: 'Index entries', draft: 'Next commit preview', mode: 'Mode', path: 'Path',
+        misconception: 'Common misconception', recovery: 'Recovery move', agent: 'AI Agent checkpoint',
+        article: 'Chinese article', lab: 'Run the temporary-repo lab', keyboard: 'Keyboard: ← → move, Home / End jump',
+        views: [['HEAD', 'last commit'], ['Index', 'commit draft'], ['Working Tree', 'files on disk']],
+        empty: 'The index matches HEAD.\nThe next commit has no changes yet.', fileCount: n => `${n} path${n === 1 ? '' : 's'} in the draft`, changed: 'changed', same: 'same',
+        announced: (n, label) => `State ${n}: ${label}`
+      }
+    };
+
+    const baseFiles = {
+      app: { path: 'app.txt', head: 'owner=team\n...\ndeploy=off' },
+      conflict: { path: 'conflict.txt', head: 'owner=human' },
+      settings: { path: 'settings.ini', head: 'mode=safe' }
+    };
+
+    const normalEntries = [
+      ['100644', 'a39e044', 0, 'app.txt'],
+      ['100644', 'c3efd06', 0, 'conflict.txt'],
+      ['100644', '7cd75d5', 0, 'settings.ini']
+    ];
+
+    const STEPS = [
+      {
+        label: { zh: '干净起点', en: 'Clean starting point' },
+        command: 'git status --short\ngit ls-files --stage',
+        output: '100644 a39e044 0\tapp.txt\n100644 c3efd06 0\tconflict.txt\n100644 7cd75d5 0\tsettings.ini',
+        status: 'clean', entries: normalEntries, draft: [],
+        files: [['app', null, null], ['conflict', null, null], ['settings', null, null]],
+        explanation: { zh: '普通路径只有 stage 0。此时 Index 与 HEAD 指向相同的内容，Working Tree 也没有额外编辑。', en: 'Normal paths use stage 0. The index matches HEAD, and the working tree has no extra edits.' },
+        misconception: { zh: 'Index 不是空目录。干净状态下，它仍保存整棵待提交树的路径条目。', en: 'The index is not empty when clean. It still contains entries for the complete draft tree.' },
+        recovery: { zh: '先用 git status --short 建立起点，再执行会改变草稿的命令。', en: 'Establish a baseline with git status --short before changing the draft.' },
+        agent: { zh: 'Agent 开始工作前记录干净状态，能区分原有改动与本次任务改动。', en: 'Record the clean baseline so the agent can separate existing work from task changes.' }
+      },
+      {
+        label: { zh: '编辑工作区', en: 'Edit the working tree' },
+        command: "sed -i '' 's/owner=team/owner=agent/' app.txt\nsed -i '' 's/deploy=off/deploy=on/' app.txt\nsed -i '' 's/mode=safe/mode=fast/' settings.ini\ngit status --short",
+        output: ' M app.txt\n M settings.ini', status: ' M · 2', entries: normalEntries, draft: [],
+        files: [['app', null, 'owner=agent\n...\ndeploy=on'], ['conflict', null, null], ['settings', null, 'mode=fast']],
+        explanation: { zh: '第二列 M 表示 Working Tree 相对 Index 已改变。Index 仍保持原草稿，所以 git diff --cached 为空。', en: 'M in the second column means the working tree differs from the index. The draft is unchanged, so git diff --cached is empty.' },
+        misconception: { zh: '磁盘上改过的内容不会自动进入下一次 commit。', en: 'Edits on disk do not automatically enter the next commit.' },
+        recovery: { zh: '如果编辑有误，先确认路径，再用 git restore -- <path> 恢复 Working Tree。', en: 'If an edit is wrong, confirm the path before restoring the working tree with git restore -- <path>.' },
+        agent: { zh: 'Agent 声称“修改完成”时，仍要区分已修改与已进入提交草稿。', en: 'When an agent says the edit is done, distinguish modified content from content placed in the commit draft.' }
+      },
+      {
+        label: { zh: '只暂存一个 hunk', en: 'Stage one hunk' },
+        command: "printf 'y\\nn\\n' | git add -p app.txt\ngit status --short", output: 'MM app.txt\n M settings.ini', status: 'MM · M',
+        entries: [['100644', '42c4cc2', 0, 'app.txt'], normalEntries[1], normalEntries[2]],
+        draft: [['app.txt', 'owner=team → owner=agent']],
+        files: [['app', 'owner=agent\n...\ndeploy=off', 'owner=agent\n...\ndeploy=on'], ['conflict', null, null], ['settings', null, 'mode=fast']],
+        explanation: { zh: '第一个 M 来自 HEAD 与 Index，第二个 M 来自 Index 与 Working Tree。同一路径现在有三份可区分的内容。', en: 'The first M compares HEAD to index; the second compares index to working tree. One path now has three distinguishable versions.' },
+        misconception: { zh: 'MM 不是重复报告同一份修改，它代表两个比较边界都存在差异。', en: 'MM is not a duplicate report. Both comparison boundaries contain a difference.' },
+        recovery: { zh: '选错 hunk 时，用 git restore --staged -- app.txt 取消暂存，磁盘编辑仍保留。', en: 'If the wrong hunk was selected, unstage app.txt while preserving disk edits with git restore --staged.' },
+        agent: { zh: '部分暂存可以隔离无关修改，但要确认拆分后的 commit 仍可独立构建和解释。', en: 'Partial staging isolates unrelated edits, but the resulting commit must still build and make sense on its own.' }
+      },
+      {
+        label: { zh: '审查提交草稿', en: 'Review the draft' },
+        command: 'git diff --cached -- app.txt\ngit diff -- app.txt',
+        output: 'cached:   owner=team → owner=agent\nunstaged: deploy=off → deploy=on', status: 'MM · M',
+        entries: [['100644', '42c4cc2', 0, 'app.txt'], normalEntries[1], normalEntries[2]],
+        draft: [['app.txt', 'owner=team → owner=agent']],
+        files: [['app', 'owner=agent\n...\ndeploy=off', 'owner=agent\n...\ndeploy=on'], ['conflict', null, null], ['settings', null, 'mode=fast']],
+        explanation: { zh: 'git diff --cached 展示 HEAD 到 Index，是提交前最直接的内容审查；git diff 展示还留在 Working Tree 的修改。', en: 'git diff --cached reviews HEAD to index, the most direct content preview before commit. git diff shows what remains only in the working tree.' },
+        misconception: { zh: '只看 git diff 会漏掉已经暂存的内容。', en: 'Looking only at git diff hides content that is already staged.' },
+        recovery: { zh: '如果草稿边界不对，先调整 Index，再重新运行两条 diff。', en: 'If the draft boundary is wrong, adjust the index and rerun both diffs.' },
+        agent: { zh: '验收 Agent 的 commit 范围时，以 git diff --cached 为主要证据。', en: 'Use git diff --cached as primary evidence when accepting an agent commit scope.' }
+      },
+      {
+        label: { zh: '误暂存配置', en: 'Stage config by mistake' },
+        command: 'git add settings.ini\ngit status --short\ngit diff --cached --stat',
+        output: 'MM app.txt\nM  settings.ini\n\n2 files changed, 2 insertions(+), 2 deletions(-)', status: 'MM · M ',
+        entries: [['100644', '42c4cc2', 0, 'app.txt'], normalEntries[1], ['100644', 'cd63ffb', 0, 'settings.ini']],
+        draft: [['app.txt', 'owner=team → owner=agent'], ['settings.ini', 'mode=safe → mode=fast']],
+        files: [['app', 'owner=agent\n...\ndeploy=off', 'owner=agent\n...\ndeploy=on'], ['conflict', null, null], ['settings', 'mode=fast', 'mode=fast']],
+        explanation: { zh: 'settings.ini 已进入 Index。即使它只是本地配置，只要草稿里存在，下一次 commit 就会包含它。', en: 'settings.ini is now in the index. Even if it is local configuration, the next commit includes it while it remains in the draft.' },
+        misconception: { zh: '文件“看起来无害”不代表它不在提交范围内。范围由 Index 决定。', en: 'A file looking harmless does not exclude it from the commit. The index defines scope.' },
+        recovery: { zh: '不要覆盖 Working Tree，只需要从 Index 精确移除这个路径。', en: 'Do not overwrite the working tree. Remove only this path from the index.' },
+        agent: { zh: 'Agent 执行 git add -A 后，必须用路径列表和 cached diff 复核草稿。', en: 'After an agent runs git add -A, verify the draft with both the path list and cached diff.' }
+      },
+      {
+        label: { zh: '安全取消暂存', en: 'Unstage safely' },
+        command: 'git restore --staged -- settings.ini\ngit status --short', output: 'MM app.txt\n M settings.ini', status: 'MM · M',
+        entries: [['100644', '42c4cc2', 0, 'app.txt'], normalEntries[1], normalEntries[2]],
+        draft: [['app.txt', 'owner=team → owner=agent']],
+        files: [['app', 'owner=agent\n...\ndeploy=off', 'owner=agent\n...\ndeploy=on'], ['conflict', null, null], ['settings', null, 'mode=fast']],
+        explanation: { zh: 'git restore --staged 默认用 HEAD 恢复该路径的 Index 条目，Working Tree 中的 mode=fast 仍然保留。', en: 'git restore --staged restores this index entry from HEAD by default, while mode=fast remains in the working tree.' },
+        misconception: { zh: '取消暂存不需要丢弃本地编辑。Index 与 Working Tree 可以分别恢复。', en: 'Unstaging does not require discarding local edits. The index and working tree can be restored separately.' },
+        recovery: { zh: '优先使用带明确路径的 git restore --staged，避免扩大影响范围。', en: 'Prefer git restore --staged with an explicit path to keep the recovery scope narrow.' },
+        agent: { zh: '恢复后再次检查 status 与 cached diff，确认无关配置已离开草稿。', en: 'After recovery, check status and the cached diff again to prove the unrelated config left the draft.' }
+      },
+      {
+        label: { zh: '进入合并冲突', en: 'Enter a merge conflict' },
+        command: 'git merge agent-change\ngit ls-files --unmerged\ngit show :1:conflict.txt\ngit show :2:conflict.txt\ngit show :3:conflict.txt',
+        output: '100644 8227059 1\tconflict.txt\n100644 c3efd06 2\tconflict.txt\n100644 d17b9a9 3\tconflict.txt\n\nbase: owner=base\nours: owner=human\ntheirs: owner=agent', status: 'UU conflict.txt',
+        entries: [['100644', '42c4cc2', 0, 'app.txt'], ['100644', '8227059', 1, 'conflict.txt'], ['100644', 'c3efd06', 2, 'conflict.txt'], ['100644', 'd17b9a9', 3, 'conflict.txt'], normalEntries[2]],
+        draft: [['app.txt', 'owner=team → owner=agent']],
+        files: [['app', 'owner=agent\n...\ndeploy=off', 'owner=agent\n...\ndeploy=on'], ['conflict', 'stage 1 / 2 / 3', '<<<<<<< HEAD\nowner=human\n=======\nowner=agent\n>>>>>>> agent-change'], ['settings', null, 'mode=fast']],
+        conflict: [['base · stage 1', 'owner=base', 'base'], ['ours · stage 2', 'owner=human', 'ours'], ['theirs · stage 3', 'owner=agent', 'theirs']],
+        explanation: { zh: '冲突路径暂时没有正常 stage 0。Index 保存共同祖先、当前分支和被合入分支三个候选 blob。', en: 'A conflicted path temporarily has no normal stage 0. The index stores base, current-branch, and merged-branch blob candidates.' },
+        misconception: { zh: '冲突信息不只存在于带标记的磁盘文件中，三个原始版本还保存在 Index。', en: 'Conflict information is not limited to marker text on disk. The index retains all three original versions.' },
+        recovery: { zh: '先读取三个 stage，再编辑解决结果；不要只凭冲突标记猜测来源。', en: 'Read all three stages before editing the resolution. Do not infer origins only from conflict markers.' },
+        agent: { zh: 'Agent 解决冲突时，应解释 base、ours、theirs 的业务差异，并展示解决后的 staged diff。', en: 'An agent resolving a conflict should explain the business differences across base, ours, and theirs, then show the staged result.' }
+      },
+      {
+        label: { zh: '写入解决结果', en: 'Record the resolution' },
+        command: "printf 'owner=human+agent\\n' > conflict.txt\ngit add conflict.txt\ngit ls-files --stage conflict.txt\ngit diff --cached --stat",
+        output: '100644 d64f293 0\tconflict.txt\n\n2 files changed, 2 insertions(+), 2 deletions(-)', status: 'M  conflict.txt',
+        entries: [['100644', '42c4cc2', 0, 'app.txt'], ['100644', 'd64f293', 0, 'conflict.txt'], normalEntries[2]],
+        draft: [['app.txt', 'owner=team → owner=agent'], ['conflict.txt', 'owner=human → owner=human+agent']],
+        files: [['app', 'owner=agent\n...\ndeploy=off', 'owner=agent\n...\ndeploy=on'], ['conflict', 'owner=human+agent', 'owner=human+agent'], ['settings', null, 'mode=fast']],
+        explanation: { zh: 'git add conflict.txt 接受当前解决内容，移除 stage 1、2、3，并为新 blob 建立 stage 0 条目。', en: 'git add conflict.txt accepts the resolution, removes stages 1, 2, and 3, and creates a stage 0 entry for the new blob.' },
+        misconception: { zh: '解决冲突后只保存文件还不够，git add 才会让 Index 记录“这个路径已解决”。', en: 'Saving the resolved file is not enough. git add tells the index that this path is resolved.' },
+        recovery: { zh: '提交前运行 git diff --cached 和测试；若结果不对，可继续编辑并再次 git add。', en: 'Run the cached diff and tests before committing. If the result is wrong, keep editing and stage it again.' },
+        agent: { zh: '最终草稿包含两个路径，deploy 与 settings 修改仍在 Working Tree，提交边界清晰可复核。', en: 'The final draft contains two paths; deploy and settings edits remain in the working tree, making the commit boundary auditable.' }
+      }
+    ];
+
+    let lang = 'zh';
+    let active = 0;
+
+    const $ = id => document.getElementById(id);
+    const escapeHtml = value => String(value).replace(/[&<>"']/g, char => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' })[char]);
+
+    function getFiles(step) {
+      return step.files.map(([key, indexValue, workValue]) => {
+        const base = baseFiles[key];
+        return { path: base.path, head: base.head, index: indexValue ?? base.head, work: workValue ?? (indexValue ?? base.head) };
+      });
+    }
+
+    function renderSteps() {
+      $('steps').innerHTML = STEPS.map((step, index) => `
+        <button class="step" type="button" data-index="${index}" ${index === active ? 'aria-current="step"' : ''}>
+          <span class="step-num">${String(index + 1).padStart(2, '0')}</span>
+          <span class="step-label">${escapeHtml(step.label[lang])}</span>
+        </button>`).join('');
+      document.querySelectorAll('.step').forEach(button => button.addEventListener('click', () => setActive(Number(button.dataset.index))));
+    }
+
+    function renderViews(step) {
+      const t = TEXT[lang];
+      const files = getFiles(step);
+      const keys = ['head', 'index', 'work'];
+      $('views').innerHTML = t.views.map(([name, note], viewIndex) => {
+        const key = keys[viewIndex];
+        return `<section class="view">
+          <div class="view-head"><span class="view-name">${name}</span><span class="view-note">${escapeHtml(note)}</span></div>
+          <div class="file-list">${files.map(file => {
+            const changed = key === 'head' ? false : file[key] !== file[key === 'index' ? 'head' : 'index'];
+            return `<div class="file ${changed ? 'changed' : ''}">
+              <div class="file-top"><span class="file-path">${escapeHtml(file.path)}</span><span class="file-tag">${changed ? t.changed : t.same}</span></div>
+              <pre>${escapeHtml(file[key])}</pre>
+            </div>`;
+          }).join('')}</div>
+        </section>`;
+      }).join('');
+    }
+
+    function renderEntries(step) {
+      $('entries').innerHTML = step.entries.map(([mode, oid, stage, path]) => `
+        <tr><td>${mode}</td><td>${oid}</td><td><span class="stage-pill s${stage}">${stage}</span></td><td>${escapeHtml(path)}</td></tr>`).join('');
+      const conflict = $('conflict');
+      if (step.conflict) {
+        conflict.hidden = false;
+        $('candidates').innerHTML = step.conflict.map(([label, content, kind]) => `
+          <div class="candidate ${kind}"><strong>${escapeHtml(label)}</strong><pre>${escapeHtml(content)}</pre></div>`).join('');
+      } else {
+        conflict.hidden = true;
+        $('candidates').innerHTML = '';
+      }
+    }
+
+    function renderDraft(step) {
+      const t = TEXT[lang];
+      if (!step.draft.length) {
+        $('draft').innerHTML = `<div class="draft-empty"><pre>${escapeHtml(t.empty)}</pre></div>`;
+        return;
+      }
+      $('draft').innerHTML = `<div class="draft-files">${step.draft.map(([path, change]) => `
+        <div class="draft-file"><strong>${escapeHtml(path)}</strong><span>${escapeHtml(change)}</span></div>`).join('')}</div>`;
+    }
+
+    function renderStaticText() {
+      const t = TEXT[lang];
+      document.documentElement.lang = lang === 'zh' ? 'zh-CN' : 'en';
+      $('page-title').textContent = t.title;
+      $('page-lead').textContent = t.lead;
+      $('rail-title').textContent = t.rail;
+      $('command-label').textContent = t.command;
+      $('output-label').textContent = t.output;
+      $('comparison-title').textContent = t.comparison;
+      $('index-title').textContent = t.index;
+      $('draft-title').textContent = t.draft;
+      $('th-mode').textContent = t.mode;
+      $('th-path').textContent = t.path;
+      $('mis-title').textContent = t.misconception;
+      $('rec-title').textContent = t.recovery;
+      $('agent-title').textContent = t.agent;
+      $('article-link').textContent = t.article;
+      $('lab-link').textContent = t.lab;
+      $('keyboard-help').textContent = t.keyboard;
+      $('lang').textContent = lang === 'zh' ? 'English' : '中文';
+    }
+
+    function render(announce = true) {
+      const step = STEPS[active];
+      const t = TEXT[lang];
+      renderStaticText();
+      renderSteps();
+      $('state-title').textContent = step.label[lang];
+      $('command').textContent = step.command;
+      $('output').textContent = step.output;
+      $('status-badge').textContent = step.status;
+      $('counter').textContent = `${active + 1} / ${STEPS.length}`;
+      $('progress').style.width = `${((active + 1) / STEPS.length) * 100}%`;
+      $('explanation').textContent = step.explanation[lang];
+      $('misconception').textContent = step.misconception[lang];
+      $('recovery').textContent = step.recovery[lang];
+      $('agent').textContent = step.agent[lang];
+      renderViews(step);
+      renderEntries(step);
+      renderDraft(step);
+      $('prev').disabled = active === 0;
+      $('next').disabled = active === STEPS.length - 1;
+      if (announce) $('live').textContent = t.announced(active + 1, step.label[lang]);
+    }
+
+    function setActive(index) {
+      active = Math.max(0, Math.min(STEPS.length - 1, index));
+      render();
+      document.querySelector(`[data-index="${active}"]`)?.focus({ preventScroll: true });
+    }
+
+    $('prev').addEventListener('click', () => setActive(active - 1));
+    $('next').addEventListener('click', () => setActive(active + 1));
+    $('lang').addEventListener('click', () => { lang = lang === 'zh' ? 'en' : 'zh'; render(); });
+    document.addEventListener('keydown', event => {
+      if (event.altKey || event.ctrlKey || event.metaKey) return;
+      if (event.key === 'ArrowLeft') { event.preventDefault(); setActive(active - 1); }
+      if (event.key === 'ArrowRight') { event.preventDefault(); setActive(active + 1); }
+      if (event.key === 'Home') { event.preventDefault(); setActive(0); }
+      if (event.key === 'End') { event.preventDefault(); setActive(STEPS.length - 1); }
+    });
+
+    render(false);
+  </script>
+</body>
+</html>

--- a/interactive/git-mental-model/index-as-draft.html
+++ b/interactive/git-mental-model/index-as-draft.html
@@ -348,7 +348,16 @@
       },
       {
         label: { zh: '编辑工作区', en: 'Edit the working tree' },
-        command: "sed -i '' 's/owner=team/owner=agent/' app.txt\nsed -i '' 's/deploy=off/deploy=on/' app.txt\nsed -i '' 's/mode=safe/mode=fast/' settings.ini\ngit status --short",
+        command: [
+          "python3 - <<'PY'",
+          'from pathlib import Path',
+          'app = Path("app.txt")',
+          'app.write_text(app.read_text().replace("owner=team", "owner=agent").replace("deploy=off", "deploy=on"))',
+          'settings = Path("settings.ini")',
+          'settings.write_text(settings.read_text().replace("mode=safe", "mode=fast"))',
+          'PY',
+          'git status --short'
+        ].join('\n'),
         output: ' M app.txt\n M settings.ini', status: ' M · 2', entries: normalEntries, draft: [],
         files: [['app', null, 'owner=agent\n...\ndeploy=on'], ['conflict', null, null], ['settings', null, 'mode=fast']],
         explanation: { zh: '第二列 M 表示 Working Tree 相对 Index 已改变。Index 仍保持原草稿，所以 git diff --cached 为空。', en: 'M in the second column means the working tree differs from the index. The draft is unchanged, so git diff --cached is empty.' },

--- a/labs/git-mental-model/03-index/README.md
+++ b/labs/git-mental-model/03-index/README.md
@@ -1,0 +1,54 @@
+# Index Draft Lab / Index 草稿实验
+
+[中文文章](../../../01-getting-started/git-mental-model-03-index.md) | [English article](../../../01-getting-started/01-getting-started_en/git-mental-model-03-index_en.md) | [Interactive demo](../../../interactive/git-mental-model/index-as-draft.html)
+
+## 中文
+
+这个实验创建一个临时 Git 仓库，并同时保留三类 Index 状态：
+
+```text
+MM app.txt       一个 hunk 已暂存，另一个 hunk 仍在 Working Tree
+UU conflict.txt  Index 保存 stage 1、2、3
+ M settings.ini  修改只在 Working Tree
+```
+
+运行：
+
+```bash
+lab_path=$(bash setup.sh)
+bash verify.sh "$lab_path"
+bash cleanup.sh "$lab_path"
+```
+
+`setup.sh` 的标准输出只有临时仓库路径。`verify.sh` 会检查 `HEAD`、Index 和 Working Tree 中的 `app.txt` 内容，确认 `git diff --cached` 只包含选中的 hunk，并验证冲突 stages 的 base、ours、theirs 内容。`cleanup.sh` 只接受带有本实验标记的仓库路径。
+
+一次运行完整自测：
+
+```bash
+bash test.sh
+```
+## English
+
+This lab creates a temporary Git repository and preserves three index states at once:
+
+```text
+MM app.txt       one hunk staged, another hunk still in the working tree
+UU conflict.txt  stages 1, 2, and 3 stored in the index
+ M settings.ini  change present only in the working tree
+```
+
+Run:
+
+```bash
+lab_path=$(bash setup.sh)
+bash verify.sh "$lab_path"
+bash cleanup.sh "$lab_path"
+```
+
+The only standard output from `setup.sh` is the temporary repository path. `verify.sh` checks the `app.txt` content in `HEAD`, the index, and the working tree; confirms that `git diff --cached` contains only the selected hunk; and verifies the base, ours, and theirs content in the conflict stages. `cleanup.sh` accepts only a repository marked as belonging to this lab.
+
+Run the full self-test with:
+
+```bash
+bash test.sh
+```

--- a/labs/git-mental-model/03-index/cleanup.sh
+++ b/labs/git-mental-model/03-index/cleanup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 1 )); then
+  echo "usage: $0 <lab-repository>" >&2
+  exit 2
+fi
+
+requested=$1
+if [[ ! -d "$requested" ]]; then
+  echo "lab repository does not exist: $requested" >&2
+  exit 1
+fi
+
+lab_dir=$(cd "$requested" && pwd -P)
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+project_root=$(cd "$script_dir/../../.." && pwd -P)
+
+if [[ "$lab_dir" == "/" || "$lab_dir" == "$HOME" || "$lab_dir" == "$project_root" ]]; then
+  echo "refusing to remove protected directory: $lab_dir" >&2
+  exit 1
+fi
+
+if [[ ! -f "$lab_dir/.git/my-git-lab" ]] || [[ "$(<"$lab_dir/.git/my-git-lab")" != "index-draft" ]]; then
+  echo "refusing to remove an unmarked directory: $lab_dir" >&2
+  exit 1
+fi
+
+rm -rf -- "$lab_dir"
+printf 'removed lab repository: %s\n' "$lab_dir"

--- a/labs/git-mental-model/03-index/expected.txt
+++ b/labs/git-mental-model/03-index/expected.txt
@@ -1,0 +1,27 @@
+Index Draft / Index 草稿
+
+git status --short
+
+MM app.txt
+UU conflict.txt
+ M settings.ini
+
+app.txt
+
+- HEAD: owner=team and deploy=off
+- Index: owner=agent and deploy=off
+- Working Tree: owner=agent and deploy=on
+- git diff --cached contains only the selected owner hunk
+- git diff contains only the remaining deploy hunk
+
+conflict.txt
+
+- stage 1: owner=base
+- stage 2: owner=human
+- stage 3: owner=agent
+
+settings.ini
+
+- Index: mode=safe
+- Working Tree: mode=fast
+- The change is outside the next commit draft

--- a/labs/git-mental-model/03-index/setup.sh
+++ b/labs/git-mental-model/03-index/setup.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# > 1 )); then
+  echo "usage: $0 [target-directory]" >&2
+  exit 2
+fi
+
+if (( $# == 1 )); then
+  lab_dir=$1
+  if [[ -e "$lab_dir" && ! -d "$lab_dir" ]]; then
+    echo "target exists and is not a directory: $lab_dir" >&2
+    exit 1
+  fi
+  mkdir -p "$lab_dir"
+  if [[ -n "$(find "$lab_dir" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+    echo "target directory must be empty: $lab_dir" >&2
+    exit 1
+  fi
+else
+  lab_dir=$(mktemp -d "${TMPDIR:-/tmp}/my-git-index-draft.XXXXXX")
+fi
+
+lab_dir=$(cd "$lab_dir" && pwd -P)
+
+git -c init.defaultBranch=main init -q "$lab_dir"
+git -C "$lab_dir" config user.name "My Git Lab"
+git -C "$lab_dir" config user.email "lab@example.com"
+printf 'index-draft\n' > "$lab_dir/.git/my-git-lab"
+
+printf '%s\n' \
+  'title=Index Lab' \
+  'owner=team' \
+  'status=draft' \
+  'scope=docs' \
+  'review=required' \
+  'tests=enabled' \
+  'release=manual' \
+  'notes=clean' \
+  'agent=idle' \
+  'limit=one' \
+  'backup=on' \
+  'format=text' \
+  'sync=off' \
+  'deploy=off' \
+  'footer=end' > "$lab_dir/app.txt"
+printf 'mode=safe\n' > "$lab_dir/settings.ini"
+printf 'owner=base\n' > "$lab_dir/conflict.txt"
+
+git -C "$lab_dir" add app.txt settings.ini conflict.txt
+GIT_AUTHOR_DATE='2026-01-01T00:00:00Z' \
+GIT_COMMITTER_DATE='2026-01-01T00:00:00Z' \
+  git -C "$lab_dir" commit -q -m "baseline"
+
+git -C "$lab_dir" switch -q -c agent-change
+printf 'owner=agent\n' > "$lab_dir/conflict.txt"
+git -C "$lab_dir" add conflict.txt
+GIT_AUTHOR_DATE='2026-01-01T00:01:00Z' \
+GIT_COMMITTER_DATE='2026-01-01T00:01:00Z' \
+  git -C "$lab_dir" commit -q -m "agent edits owner"
+
+git -C "$lab_dir" switch -q main
+printf 'owner=human\n' > "$lab_dir/conflict.txt"
+git -C "$lab_dir" add conflict.txt
+GIT_AUTHOR_DATE='2026-01-01T00:02:00Z' \
+GIT_COMMITTER_DATE='2026-01-01T00:02:00Z' \
+  git -C "$lab_dir" commit -q -m "human edits owner"
+
+if git -C "$lab_dir" merge agent-change >/dev/null 2>&1; then
+  echo "expected conflict.txt to conflict" >&2
+  exit 1
+fi
+git -C "$lab_dir" rev-parse -q --verify MERGE_HEAD >/dev/null
+
+printf '%s\n' \
+  'title=Index Lab' \
+  'owner=agent' \
+  'status=draft' \
+  'scope=docs' \
+  'review=required' \
+  'tests=enabled' \
+  'release=manual' \
+  'notes=clean' \
+  'agent=idle' \
+  'limit=one' \
+  'backup=on' \
+  'format=text' \
+  'sync=off' \
+  'deploy=on' \
+  'footer=end' > "$lab_dir/app.txt"
+
+printf 'y\nn\n' | git -C "$lab_dir" add -p app.txt >/dev/null
+printf 'mode=fast\n' > "$lab_dir/settings.ini"
+
+printf '%s\n' "$lab_dir"

--- a/labs/git-mental-model/03-index/test.sh
+++ b/labs/git-mental-model/03-index/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+lab_dir=$(bash "$script_dir/setup.sh")
+
+cleanup() {
+  if [[ -d "$lab_dir" ]]; then
+    bash "$script_dir/cleanup.sh" "$lab_dir" >/dev/null
+  fi
+}
+trap cleanup EXIT
+
+bash "$script_dir/verify.sh" "$lab_dir"

--- a/labs/git-mental-model/03-index/verify.sh
+++ b/labs/git-mental-model/03-index/verify.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 1 )); then
+  echo "usage: $0 <lab-repository>" >&2
+  exit 2
+fi
+
+lab_dir=$1
+if [[ ! -f "$lab_dir/.git/my-git-lab" ]] || [[ "$(<"$lab_dir/.git/my-git-lab")" != "index-draft" ]]; then
+  echo "not an index-draft lab repository: $lab_dir" >&2
+  exit 1
+fi
+
+expected_status=$'MM app.txt\nUU conflict.txt\n M settings.ini'
+actual_status=$(git -C "$lab_dir" status --short)
+[[ "$actual_status" == "$expected_status" ]] || {
+  printf 'unexpected status:\n%s\n' "$actual_status" >&2
+  exit 1
+}
+
+app_stage=$(git -C "$lab_dir" ls-files --stage -- app.txt | awk '{print $3}')
+settings_stage=$(git -C "$lab_dir" ls-files --stage -- settings.ini | awk '{print $3}')
+[[ "$app_stage" == "0" ]] || { echo "app.txt is not at stage 0" >&2; exit 1; }
+[[ "$settings_stage" == "0" ]] || { echo "settings.ini is not at stage 0" >&2; exit 1; }
+
+app_index_oid=$(git -C "$lab_dir" ls-files --stage -- app.txt | awk '{print $2}')
+settings_index_oid=$(git -C "$lab_dir" ls-files --stage -- settings.ini | awk '{print $2}')
+app_index_content=$(git -C "$lab_dir" cat-file -p "$app_index_oid")
+settings_index_content=$(git -C "$lab_dir" cat-file -p "$settings_index_oid")
+app_head_content=$(git -C "$lab_dir" show HEAD:app.txt)
+
+grep -qx 'owner=team' <<<"$app_head_content" || { echo "HEAD app owner mismatch" >&2; exit 1; }
+grep -qx 'deploy=off' <<<"$app_head_content" || { echo "HEAD app deploy mismatch" >&2; exit 1; }
+grep -qx 'owner=agent' <<<"$app_index_content" || { echo "index app owner mismatch" >&2; exit 1; }
+grep -qx 'deploy=off' <<<"$app_index_content" || { echo "index app deploy mismatch" >&2; exit 1; }
+grep -qx 'owner=agent' "$lab_dir/app.txt" || { echo "working-tree app owner mismatch" >&2; exit 1; }
+grep -qx 'deploy=on' "$lab_dir/app.txt" || { echo "working-tree app deploy mismatch" >&2; exit 1; }
+[[ "$settings_index_content" == "mode=safe" ]] || { echo "index settings mismatch" >&2; exit 1; }
+[[ "$(<"$lab_dir/settings.ini")" == "mode=fast" ]] || { echo "working-tree settings mismatch" >&2; exit 1; }
+
+cached_diff=$(git -C "$lab_dir" diff --cached -- app.txt)
+working_diff=$(git -C "$lab_dir" diff -- app.txt)
+grep -q '^-owner=team' <<<"$cached_diff" || { echo "selected owner hunk missing from cached diff" >&2; exit 1; }
+grep -q '^+owner=agent' <<<"$cached_diff" || { echo "selected owner hunk missing from cached diff" >&2; exit 1; }
+if grep -q 'deploy=' <<<"$cached_diff"; then
+  echo "unstaged deploy hunk leaked into cached diff" >&2
+  exit 1
+fi
+grep -q '^-deploy=off' <<<"$working_diff" || { echo "deploy hunk missing from working diff" >&2; exit 1; }
+grep -q '^+deploy=on' <<<"$working_diff" || { echo "deploy hunk missing from working diff" >&2; exit 1; }
+if grep -q 'owner=' <<<"$working_diff"; then
+  echo "staged owner hunk leaked into working diff" >&2
+  exit 1
+fi
+
+conflict_entries=$(git -C "$lab_dir" ls-files --stage -- conflict.txt)
+[[ "$(wc -l <<<"$conflict_entries" | tr -d ' ')" == "3" ]] || { echo "conflict stages missing" >&2; exit 1; }
+[[ "$(awk 'NR == 1 {print $3}' <<<"$conflict_entries")" == "1" ]] || { echo "stage 1 missing" >&2; exit 1; }
+[[ "$(awk 'NR == 2 {print $3}' <<<"$conflict_entries")" == "2" ]] || { echo "stage 2 missing" >&2; exit 1; }
+[[ "$(awk 'NR == 3 {print $3}' <<<"$conflict_entries")" == "3" ]] || { echo "stage 3 missing" >&2; exit 1; }
+
+[[ "$(git -C "$lab_dir" show ':1:conflict.txt')" == "owner=base" ]] || { echo "stage 1 content mismatch" >&2; exit 1; }
+[[ "$(git -C "$lab_dir" show ':2:conflict.txt')" == "owner=human" ]] || { echo "stage 2 content mismatch" >&2; exit 1; }
+[[ "$(git -C "$lab_dir" show ':3:conflict.txt')" == "owner=agent" ]] || { echo "stage 3 content mismatch" >&2; exit 1; }
+
+printf 'ok: app.txt HEAD owner=team -> Index owner=agent -> Working Tree deploy=on\n'
+printf 'ok: git diff --cached contains only the selected owner hunk\n'
+printf 'ok: conflict.txt stages 1=base, 2=human, 3=agent\n'
+printf 'ok: settings.ini remains outside the next commit draft\n'


### PR DESCRIPTION
## 概要

- 新增中英文第三章，讲清 Index、部分暂存、`git diff --cached` 与冲突 stage 1、2、3
- 新增 8 状态双语交互演示，包含提交草稿预览、安全取消暂存和冲突候选检查
- 新增可重复运行的临时仓库实验与自动验证脚本
- 更新中英文学习路径、系列入口和 GitHub Actions 实验检查

## 验证

- `python3 scripts/check-docs.py`
- `python3 scripts/check-links.py --no-external`
- `bash labs/git-mental-model/03-index/test.sh`
- `git diff --check`
- 交互页 JavaScript 静态语法检查
- 浏览器检查：桌面与 390px 窄屏、中英文切换、Home / End 与方向键导航、控制台无警告或错误
- 页面中的短对象 ID 已与实验仓库真实 blob 对账

## AI 协作说明

- 使用的 AI 工具：OpenAI Codex
- 人工检查过的文件：尚无，等待维护者在本 PR 中检查
- 建议重点检查：
  - `01-getting-started/git-mental-model-03-index.md`
  - `01-getting-started/01-getting-started_en/git-mental-model-03-index_en.md`
  - `interactive/git-mental-model/index-as-draft.html`
  - `labs/git-mental-model/03-index/`
